### PR TITLE
Uhf 5309 organization taxonomy

### DIFF
--- a/conf/cmi/core.entity_form_display.taxonomy_term.organization.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.organization.default.yml
@@ -1,0 +1,101 @@
+uuid: b7a65bbd-74fe-4071-bd07-82fc451073d7
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organization.field_default_image
+    - field.field.taxonomy_term.organization.field_external_id
+    - image.style.thumbnail
+    - taxonomy.vocabulary.organization
+  module:
+    - field_group
+    - image
+    - path
+    - readonly_field_widget
+    - text
+third_party_settings:
+  field_group:
+    group_default_description:
+      children:
+        - description
+        - field_default_image
+      label: 'Default description'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Default values for the description section. To be used as a fallback, if these values aren''t provided by the migration.'
+        required_fields: true
+_core:
+  default_config_hash: 65qHo87IfHIjBiM_kvZxv8m6M4NGwnmkaC5tC3MDGTk
+id: taxonomy_term.organization.default
+targetEntityType: taxonomy_term
+bundle: organization
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_default_image:
+    type: image_image
+    weight: 4
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_external_id:
+    type: readonly_field_widget
+    weight: 3
+    region: content
+    settings:
+      label: above
+      formatter_type: text_span
+      show_description: '1'
+      formatter_settings:
+        string:
+          link_to_entity: 0
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  translation:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.taxonomy_term.organization.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.organization.default.yml
@@ -1,0 +1,44 @@
+uuid: b682b0ea-dd3a-414c-93fb-8e84c1687a61
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organization.field_default_image
+    - field.field.taxonomy_term.organization.field_external_id
+    - taxonomy.vocabulary.organization
+  module:
+    - image
+    - text
+_core:
+  default_config_hash: Gz4Fau02tN8C3_Pjzxy-VS8VljtfEJNKjRK2Tfdh1Ag
+id: taxonomy_term.organization.default
+targetEntityType: taxonomy_term
+bundle: organization
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_default_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_external_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden:
+  langcode: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -48,6 +48,7 @@ module:
   helfi_media: 0
   helfi_platform_config: 0
   helfi_proxy: 0
+  helfi_rekry_content: 0
   helfi_toc: 0
   image: 0
   image_style_quality: 0
@@ -79,6 +80,7 @@ module:
   purge_processor_cron: 0
   purge_queuer_coretags: 0
   purge_tokens: 0
+  readonly_field_widget: 0
   redirect: 0
   responsive_image: 0
   role_delegation: 0

--- a/conf/cmi/field.field.taxonomy_term.organization.field_default_image.yml
+++ b/conf/cmi/field.field.taxonomy_term.organization.field_default_image.yml
@@ -1,0 +1,40 @@
+uuid: eec2f942-ec17-4287-8c73-77f0244b8374
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_default_image
+    - taxonomy.vocabulary.organization
+  module:
+    - image
+_core:
+  default_config_hash: k0B7Ajzqy8M9nIRugGxMAhjHY4rnYb-0BWGrzjT27NI
+id: taxonomy_term.organization.field_default_image
+field_name: field_default_image
+entity_type: taxonomy_term
+bundle: organization
+label: 'Default image'
+description: 'Provide a default image for the organization. This image is shown in the organization''s description.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/conf/cmi/field.field.taxonomy_term.organization.field_external_id.yml
+++ b/conf/cmi/field.field.taxonomy_term.organization.field_external_id.yml
@@ -1,0 +1,21 @@
+uuid: 5a361ca2-f7e0-4af9-ba27-df28b937b859
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_external_id
+    - taxonomy.vocabulary.organization
+_core:
+  default_config_hash: 1iWg83QCF2NgvSSchoXSDbCxTs5JjQIaeAc1ZzmDbUg
+id: taxonomy_term.organization.field_external_id
+field_name: field_external_id
+entity_type: taxonomy_term
+bundle: organization
+label: 'External ID'
+description: 'Helbit ID for the organization.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.taxonomy_term.field_default_image.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_default_image.yml
@@ -1,0 +1,32 @@
+uuid: 76518bbf-2f6b-47e2-9f5d-5b8741144401
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - taxonomy
+_core:
+  default_config_hash: olpcuN8xV7VIRQHtHinPm0MxybJI0WBh51dSrYy7hGw
+id: taxonomy_term.field_default_image
+field_name: field_default_image
+entity_type: taxonomy_term
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.taxonomy_term.field_external_id.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_external_id.yml
@@ -1,0 +1,23 @@
+uuid: a49925e6-5bf2-4523-9488-6087e21c77a9
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+_core:
+  default_config_hash: JR48FK3uF4jZIz3Xv7PkBbMuA-RjSBJ_YmoKhcNYp90
+id: taxonomy_term.field_external_id
+field_name: field_external_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.taxonomy_term.organization.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.organization.yml
@@ -1,0 +1,18 @@
+uuid: 7230f1e2-f670-4a2c-ac07-0d055ad7d732
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organization
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+_core:
+  default_config_hash: JDgbX1-XnNZ9kUCKxxwnANlm6mj3IDJLgnc4E_-JElI
+id: taxonomy_term.organization
+target_entity_type_id: taxonomy_term
+target_bundle: organization
+default_langcode: en
+language_alterable: false

--- a/conf/cmi/language/fi/field.field.taxonomy_term.organization.field_default_image.yml
+++ b/conf/cmi/language/fi/field.field.taxonomy_term.organization.field_default_image.yml
@@ -1,0 +1,2 @@
+label: Oletuskuva
+description: 'Organisaation oletuskuva. Kuva näytetään orgnisaation kuvauksen yhteydessä.'

--- a/conf/cmi/language/fi/field.field.taxonomy_term.organization.field_external_id.yml
+++ b/conf/cmi/language/fi/field.field.taxonomy_term.organization.field_external_id.yml
@@ -1,0 +1,2 @@
+label: 'Ulkopuolinen ID'
+description: 'Orgnisaation Helbit-id.'

--- a/conf/cmi/language/fi/taxonomy.vocabulary.organization.yml
+++ b/conf/cmi/language/fi/taxonomy.vocabulary.organization.yml
@@ -1,0 +1,2 @@
+name: Organisaatio
+description: 'Lista organisaatiosta. Haetaan automaattisesti Helbitistä.'

--- a/conf/cmi/language/sv/field.field.taxonomy_term.organization.field_default_image.yml
+++ b/conf/cmi/language/sv/field.field.taxonomy_term.organization.field_default_image.yml
@@ -1,0 +1,2 @@
+label: Standardbild
+description: 'Ange en standardbild för organisationen. Denna bild visas i organisationens beskrivning.'

--- a/conf/cmi/language/sv/field.field.taxonomy_term.organization.field_external_id.yml
+++ b/conf/cmi/language/sv/field.field.taxonomy_term.organization.field_external_id.yml
@@ -1,0 +1,2 @@
+label: 'Externt ID'
+description: 'Helbit ID för organisationen.'

--- a/conf/cmi/language/sv/taxonomy.vocabulary.organization.yml
+++ b/conf/cmi/language/sv/taxonomy.vocabulary.organization.yml
@@ -1,0 +1,2 @@
+name: Organisation
+description: 'Migrerade från Helbit.'

--- a/conf/cmi/taxonomy.vocabulary.organization.yml
+++ b/conf/cmi/taxonomy.vocabulary.organization.yml
@@ -1,0 +1,10 @@
+uuid: 5e21a2e9-ef52-4981-b451-1097ba45d3a4
+langcode: en
+status: true
+dependencies: {  }
+_core:
+  default_config_hash: imbiffxfITceifli0OieLN3Mo7E3kqXCKKbQKjzqG1Q
+name: Organization
+vid: organization
+description: 'List or organizations. Migrated from Helbit.'
+weight: 0

--- a/public/modules/custom/helfi_rekry_content/config/install/core.entity_form_display.taxonomy_term.organization.default.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/core.entity_form_display.taxonomy_term.organization.default.yml
@@ -1,0 +1,98 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organization.field_default_image
+    - field.field.taxonomy_term.organization.field_external_id
+    - image.style.thumbnail
+    - taxonomy.vocabulary.organization
+  module:
+    - field_group
+    - image
+    - path
+    - readonly_field_widget
+    - text
+third_party_settings:
+  field_group:
+    group_default_description:
+      children:
+        - description
+        - field_default_image
+      label: 'Default description'
+      region: content
+      parent_name: ''
+      weight: 2
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: 'Default values for the description section. To be used as a fallback, if these values aren''t provided by the migration.'
+        required_fields: true
+id: taxonomy_term.organization.default
+targetEntityType: taxonomy_term
+bundle: organization
+mode: default
+content:
+  description:
+    type: text_textarea
+    weight: 3
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  field_default_image:
+    type: image_image
+    weight: 4
+    region: content
+    settings:
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+  field_external_id:
+    type: readonly_field_widget
+    weight: 3
+    region: content
+    settings:
+      label: above
+      formatter_type: text_span
+      show_description: '1'
+      formatter_settings:
+        string:
+          link_to_entity: 0
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 0
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: 1
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 6
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 7
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  translation:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/public/modules/custom/helfi_rekry_content/config/install/core.entity_view_display.taxonomy_term.organization.default.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/core.entity_view_display.taxonomy_term.organization.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.organization.field_default_image
+    - field.field.taxonomy_term.organization.field_external_id
+    - taxonomy.vocabulary.organization
+  module:
+    - image
+    - text
+id: taxonomy_term.organization.default
+targetEntityType: taxonomy_term
+bundle: organization
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_default_image:
+    type: image
+    label: above
+    settings:
+      image_link: ''
+      image_style: ''
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_external_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
+    region: content
+hidden:
+  langcode: true

--- a/public/modules/custom/helfi_rekry_content/config/install/field.field.taxonomy_term.organization.field_default_image.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/field.field.taxonomy_term.organization.field_default_image.yml
@@ -1,0 +1,37 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_default_image
+    - taxonomy.vocabulary.organization
+  module:
+    - image
+id: taxonomy_term.organization.field_default_image
+field_name: field_default_image
+entity_type: taxonomy_term
+bundle: organization
+label: 'Default image'
+description: 'Provide a default image for the organization. This image is shown in the organization''s description.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: '[date:custom:Y]-[date:custom:m]'
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: ''
+  max_resolution: ''
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: true
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+field_type: image

--- a/public/modules/custom/helfi_rekry_content/config/install/field.field.taxonomy_term.organization.field_external_id.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/field.field.taxonomy_term.organization.field_external_id.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_external_id
+    - taxonomy.vocabulary.organization
+id: taxonomy_term.organization.field_external_id
+field_name: field_external_id
+entity_type: taxonomy_term
+bundle: organization
+label: 'External ID'
+description: 'Helbit ID for the organization.'
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/public/modules/custom/helfi_rekry_content/config/install/field.storage.taxonomy_term.field_default_image.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/field.storage.taxonomy_term.field_default_image.yml
@@ -1,0 +1,30 @@
+uuid: 76518bbf-2f6b-47e2-9f5d-5b8741144401
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - taxonomy
+id: taxonomy_term.field_default_image
+field_name: field_default_image
+entity_type: taxonomy_term
+type: image
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/helfi_rekry_content/config/install/field.storage.taxonomy_term.field_external_id.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/field.storage.taxonomy_term.field_external_id.yml
@@ -1,0 +1,21 @@
+uuid: a49925e6-5bf2-4523-9488-6087e21c77a9
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_external_id
+field_name: field_external_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/helfi_rekry_content/config/install/language.content_settings.taxonomy_term.organization.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/language.content_settings.taxonomy_term.organization.yml
@@ -1,0 +1,15 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.organization
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.organization
+target_entity_type_id: taxonomy_term
+target_bundle: organization
+default_langcode: en
+language_alterable: false

--- a/public/modules/custom/helfi_rekry_content/config/install/taxonomy.vocabulary.organization.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/taxonomy.vocabulary.organization.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: Organization
+vid: organization
+description: 'List or organizations. Migrated from Helbit.'
+weight: 0

--- a/public/modules/custom/helfi_rekry_content/config/language/fi/field.field.taxonomy_term.organization.field_default_image.yml
+++ b/public/modules/custom/helfi_rekry_content/config/language/fi/field.field.taxonomy_term.organization.field_default_image.yml
@@ -1,0 +1,2 @@
+label: Oletuskuva
+description: 'Organisaation oletuskuva. Kuva näytetään orgnisaation kuvauksen yhteydessä.'

--- a/public/modules/custom/helfi_rekry_content/config/language/fi/field.field.taxonomy_term.organization.field_external_id.yml
+++ b/public/modules/custom/helfi_rekry_content/config/language/fi/field.field.taxonomy_term.organization.field_external_id.yml
@@ -1,0 +1,2 @@
+label: 'Ulkopuolinen ID'
+description: 'Orgnisaation Helbit-id.'

--- a/public/modules/custom/helfi_rekry_content/config/language/fi/taxonomy.vocabulary.organization.yml
+++ b/public/modules/custom/helfi_rekry_content/config/language/fi/taxonomy.vocabulary.organization.yml
@@ -1,0 +1,2 @@
+name: Organisaatio
+description: 'Lista organisaatiosta. Haetaan automaattisesti Helbitistä.'

--- a/public/modules/custom/helfi_rekry_content/config/language/sv/field.field.taxonomy_term.organization.field_default_image.yml
+++ b/public/modules/custom/helfi_rekry_content/config/language/sv/field.field.taxonomy_term.organization.field_default_image.yml
@@ -1,0 +1,2 @@
+label: Standardbild
+description: 'Ange en standardbild för organisationen. Denna bild visas i organisationens beskrivning.'

--- a/public/modules/custom/helfi_rekry_content/config/language/sv/field.field.taxonomy_term.organization.field_external_id.yml
+++ b/public/modules/custom/helfi_rekry_content/config/language/sv/field.field.taxonomy_term.organization.field_external_id.yml
@@ -1,0 +1,2 @@
+label: 'Externt ID'
+description: 'Helbit ID för organisationen.'

--- a/public/modules/custom/helfi_rekry_content/config/language/sv/taxonomy.vocabulary.organization.yml
+++ b/public/modules/custom/helfi_rekry_content/config/language/sv/taxonomy.vocabulary.organization.yml
@@ -1,0 +1,2 @@
+name: Organisation
+description: 'Migrerade från Helbit.'

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.info.yml
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.info.yml
@@ -1,0 +1,11 @@
+name: 'HELfi Rekry Content'
+type: module
+core_version_requirement: '^8.9 || ^9'
+dependencies:
+  - 'drupal:ckeditor'
+  - 'drupal:content_translation'
+  - 'drupal:editor'
+  - 'drupal:language'
+  - 'drupal:taxonomy'
+  - 'helfi_platform_config:helfi_platform_config'
+package: HELfi

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * @file
+ * Contains install functions for HELfi Rekry Content module
+ */
+
+use Drupal\helfi_platform_config\ConfigHelper;
+
+/**
+ * Implements hook_install().
+ */
+function helfi_rekry_content_install($is_syncing) {
+  // Do not perform following steps if the module is being installed as part
+  // of a configuration import.
+  if (!$is_syncing && Drupal::moduleHandler()->moduleExists('update_helper')) {
+    helfi_rekry_content_update_9001();
+  }
+}
+
+/**
+ * HELfi Rekry Content initial configurations
+ */
+function helfi_rekry_content_update_9001() {
+  // Install config translations
+  $configTranslationLocation = dirname(__FILE__) . '/config/language/';
+
+  $configurations = [
+    'field.field.taxonomy_term.organization.field_default_image',
+    'field.field.taxonomy_term.organization.field_external_id',
+    'taxonomy.vocabulary.organization'
+  ];
+
+  foreach($configurations as $configuration) {
+    ConfigHelper::installNewConfigTranslation($configTranslationLocation, $configuration);
+  }
+}


### PR DESCRIPTION
# [Rekry: Organization taxonomy](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5309)

## What was done
- Added a simple module for adding content-related features
- Added organization taxonomy
- Enabled `readonly_field_widget`

## How to test
- Checkout to branch. Run `make drush-cr drush-cim`
- Check out [available taxonomies](https://helfi-rekry.docker.so/fi/admin/structure/taxonomy). Organizations-taxonomy should be listed there.
- Check that available fields correspond to those in the ticket. 
- Check that configs and field descriptions make sense