### PR TITLE
Update select2 icons settings

### DIFF
--- a/conf/cmi/select2_icon.settings.yml
+++ b/conf/cmi/select2_icon.settings.yml
@@ -1,4 +1,3 @@
 _core:
   default_config_hash: MC-TKIpL-pL-xdDFY5NSz8A09wulfwE5RmtauLkC1-k
-path_to_json: /themes/contrib/hdbt/src/icons/ui-icons.json
-path_to_sprite: /themes/contrib/hdbt/dist/icons/sprite.svg
+path_to_json: /themes/contrib/hdbt/src/icons/editor-selectable-icons.json


### PR DESCRIPTION
# Fix path to icons
Fixes Drupal AJAX issues when adding content paragraphs

## What was done
Path to icons in select2.settings is outdated -> updated it to current

## How to install
* Run `git fetch; git checkout origin/UHF-X-fix-path-to-icons`
* Run `make drush-cr drush-cim`

## How to test
Try adding icon-reliant paragraphs to a landing page or standard page. These were reportedly broken:
- Hero
- Accordion
- Content liftup
- Banner
- Contact card

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
