### PR TITLE
HELBIT_CLIENT_ID to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       DRUPAL_VARNISH_HOST: "${COMPOSE_PROJECT_NAME}-varnish"
       DRUPAL_VARNISH_PORT: 6081
       REDIS_HOST: redis
+      HELBIT_CLIENT_ID: "${HELBIT_CLIENT_ID}"
     extra_hosts:
       - "host.docker.internal:host-gateway"
       - "${DRUPAL_HOSTNAME}:host-gateway"


### PR DESCRIPTION
# Add HELBIT_CLIENT_ID to docker.compose.yml
HELBIT_CLIENT_ID isn't being read from the .env file right now - add it to docker-compose.yml for ease of development

## What was done
Added HELBIT_CLIENT_ID to docker-compose.yml

## How to install

- Run `git fetch; git co origin/UHF-X-add-helbit-id-to-docker`
- Make sure you have HELBIT_CLIENT_ID value in your .env `HELBIT_CLIENT_ID=somevalue`
- Run `docker-compose up --build -d app`

## How to test
- `make shell` into the container and run `printenv`. You should be able to see the `HELBIT_CLIENT_ID` value listed.

* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)

