### PR TITLE
UHF-5304: Fix mistake in url validation

### DIFF
--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -86,7 +86,7 @@ function _helfi_rekry_check_video_url(string|NULL $url = NULL): ?string {
     return $url;
   }
   catch (\throwable $e) {
-    \Drupal::logger('helfi_rekry_content')->notice('Video embed url "' . $url . '"failed validation with message: ' . $e->getMessage());
+    \Drupal::logger('helfi_rekry_content')->notice('Video embed url "' . $url . '" failed validation with message: ' . $e->getMessage());
     throw new MigrateSkipRowException();
   }
 }

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -80,10 +80,6 @@ function _helfi_rekry_content_get_media_image(string|NULL $fid = NULL): ?string 
  *   Valid video url or null
  */
 function _helfi_rekry_check_video_url(string|NULL $url = NULL): ?string {
-  if (!$url) {
-    return NULL;
-  }
-
   try {
     $resolver = \Drupal::service('media.oembed.url_resolver');
     $validate = $resolver->getProviderByUrl($url);
@@ -91,10 +87,8 @@ function _helfi_rekry_check_video_url(string|NULL $url = NULL): ?string {
   }
   catch (\throwable $e) {
     \Drupal::logger('helfi_rekry_content')->notice('Video embed url "' . $url . '"failed validation with message: ' . $e->getMessage());
-    return NULL;
+    throw new MigrateSkipRowException();
   }
-
-  return NULL;
 }
 
 /**


### PR DESCRIPTION
# [UHF-5304](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5304)
<!-- What problem does this solve? -->

Fixes issue where remote videos without url were created

## What was done
<!-- Describe what was done -->

* Fixed url validation function 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-5304-video-migration-fix`
  * `make fresh`
* Run `make drush-cr`
* Run `make shell` and in the shell run
    * `drush mim helfi_rekry_videos:all`
    * If you don't have any job listings in your local run `drush mim helfi_rekry_job_listings:all` or if you already have some run `drush mim helfi_rekry_job_listings:all --update`
* Check that the videos are created, should be 3
* One of the created entities have a faulty url but this will be communicated to the PO that they shouldn't put this type (https://youtu.be/GJCieGXCClQ    ja    https://fb.watch/aDNyqSqWlF/) or urls to the data

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

Run the migration and check that the video entities are created. After updating/creating the job listing nodes, check that the video goes to the correct place and the job listing has the video.


* [ ] Check that this feature works
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
