### PR TITLE
UHF-5991 Organization default picture

### DIFF
--- a/conf/cmi/core.entity_view_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.default.yml
@@ -19,6 +19,7 @@ dependencies:
     - field.field.node.job_listing.field_organization_name
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
+    - field.field.node.job_listing.field_prevent_publishing
     - field.field.node.job_listing.field_recruitment_id
     - field.field.node.job_listing.field_recruitment_type
     - field.field.node.job_listing.field_salary
@@ -26,9 +27,11 @@ dependencies:
     - field.field.node.job_listing.field_task_area
     - field.field.node.job_listing.field_video
     - field.field.node.job_listing.job_description
+    - image.style.3_2_m_2x
     - node.type.job_listing
   module:
     - link
+    - media
     - text
     - user
 id: node.job_listing.default
@@ -68,11 +71,13 @@ content:
     weight: 0
     region: content
   field_image:
-    type: entity_reference_entity_view
+    type: media_thumbnail
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      image_link: ''
+      image_style: 3_2_m_2x
+      image_loading:
+        attribute: lazy
     third_party_settings: {  }
     weight: 13
     region: content

--- a/conf/cmi/core.entity_view_display.taxonomy_term.organization.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.organization.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.taxonomy_term.organization.field_default_image
     - field.field.taxonomy_term.organization.field_external_id
+    - image.style.3_2_m_2x
     - taxonomy.vocabulary.organization
   module:
     - image
@@ -28,7 +29,7 @@ content:
     label: above
     settings:
       image_link: ''
-      image_style: ''
+      image_style: 3_2_m_2x
       image_loading:
         attribute: lazy
     third_party_settings: {  }

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -226,10 +226,10 @@ function template_preprocess_organization_information_block(array &$variables) :
   $organization_default_image = $organization->get("field_default_image")->first()->view([
     'type' => 'image',
     'label' => 'hidden',
-    'settings' => array(
+    'settings' => [
       'image_style' => '3_2_m_2x',
       'image_link' => '',
-    ),
+    ],
   ]);
   $variables['content']['organization_default_image'] = $organization_default_image;
 }

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -211,4 +211,25 @@ function template_preprocess_organization_information_block(array &$variables) :
   foreach (Element::children($variables['elements']) as $key) {
     $variables['content'][$key] = $variables['elements'][$key];
   }
+
+  // Check if there is default picture set for organization.
+  if (empty($variables["elements"]["field_organization"]["#items"])) {
+    return;
+  }
+  $organization_id = $variables["elements"]["field_organization"]["#items"]->target_id;
+  $organization = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($organization_id);
+
+  if (empty($organization->get("field_default_image")->first())) {
+    return;
+  }
+
+  $organization_default_image = $organization->get("field_default_image")->first()->view([
+    'type' => 'image',
+    'label' => 'hidden',
+    'settings' => array(
+      'image_style' => '3_2_m_2x',
+      'image_link' => '',
+    ),
+  ]);
+  $variables['content']['organization_default_image'] = $organization_default_image;
 }

--- a/public/modules/custom/helfi_rekry_content/templates/organization-information-block.html.twig
+++ b/public/modules/custom/helfi_rekry_content/templates/organization-information-block.html.twig
@@ -2,6 +2,8 @@
   <div class="job-listing__image">
     {% if content.field_image|render %}
       {{ content.field_image }}
+    {% elseif content.organization_default_image|render %}
+      {{ content.organization_default_image }}
     {% else %}
       {% include '@hdbt/media/image--card.html.twig' with {content: '' } %}
     {% endif %}

--- a/public/themes/custom/hdbt_subtheme/dist/css/styles.min.css
+++ b/public/themes/custom/hdbt_subtheme/dist/css/styles.min.css
@@ -1,1 +1,286 @@
-.job-listing__organization-name{--line-height: 1.5555555556;font-size:1.125rem;font-weight:400;line-height:var(--line-height);display:-webkit-box;display:-ms-flexbox;display:flex;margin-top:16px}@media(min-width: 768px){.job-listing__organization-name{margin-top:24px}}.organization{display:-webkit-box;display:-ms-flexbox;display:flex;margin-right:8px;position:relative}.organization::after{content:","}.organization:last-child{margin-right:0}.organization:last-child::after{display:none}.job-listing__link{margin-top:16px;width:100%}@media(min-width: 768px){.job-listing__link{margin-top:24px;width:auto}}.job-listing__link:last-of-type{margin-top:32px}@media(min-width: 768px){.job-listing__link:last-of-type{margin-top:48px}}.job-listing__job-description{--line-height: 1.5555555556;font-size:1.125rem;font-weight:400;line-height:var(--line-height);margin-top:16px}@media(min-width: 768px){.job-listing__job-description{margin-top:48px}}.job-listing__job-description p:first-child{margin-top:0}.job-listing__salary-class__content{--line-height: 1.5555555556;font-size:1.125rem;font-weight:400;line-height:var(--line-height)}.job-listing__sidebar{background-color:var(--hdbt-color-palette--secondary)}.job-listing__organization-information{padding:24px}.job-listing__image img{display:block;height:auto;max-width:100%;overflow:hidden}.job-listing__organization{--line-height: 1.5;font-size:1rem;font-weight:700;line-height:var(--line-height);margin-top:0}@media(min-width: 992px){.job-listing__organization{--line-height: 1.5555555556;font-size:1.125rem;font-weight:700}}.job-listing__organization-description{--line-height: 1.5;font-size:1rem;font-weight:400;line-height:var(--line-height);margin-top:8px}.job-listing__organization-description p:first-child{margin-top:0}.node--type-job-listing .component--remote-video{margin-top:32px}@media(min-width: 992px){.node--type-job-listing .component--remote-video{margin-top:48px}}.node--view-mode-full .content-tags{margin-top:24px}.node--view-mode-teaser{position:relative;padding:32px;background-color:#fff;margin-bottom:24px;display:-webkit-box;display:-ms-flexbox;display:flex;-webkit-box-orient:vertical;-webkit-box-direction:normal;-ms-flex-direction:column;flex-direction:column}.node--view-mode-teaser:hover .hel-icon--arrow-right{-webkit-transform:translateX(4px);transform:translateX(4px)}@media(prefers-reduced-motion){.node--view-mode-teaser:hover .hel-icon--arrow-right{-webkit-transform:none;transform:none}}@media(min-width: 992px){.node--view-mode-teaser{-webkit-box-orient:horizontal;-webkit-box-direction:normal;-ms-flex-direction:row;flex-direction:row}}@media(min-width: 992px){.node--view-mode-teaser .job-listing__container-left{width:70%;padding-right:32px}}.node--view-mode-teaser .job-listing__container-right{position:relative;padding-right:48px}@media(min-width: 992px){.node--view-mode-teaser .job-listing__container-right{width:30%}}.node--view-mode-teaser .job-listing__container-right .hel-icon{position:absolute;bottom:0;right:0;width:32px;height:32px;-webkit-transition:-webkit-transform .2s linear;transition:-webkit-transform .2s linear;transition:transform .2s linear;transition:transform .2s linear, -webkit-transform .2s linear}@media(prefers-reduced-motion){.node--view-mode-teaser .job-listing__container-right .hel-icon{-webkit-transition:none;transition:none}}.node--view-mode-teaser .job-listing__metadata{width:100%}.node--view-mode-teaser .job-listing__metadata__label{display:-webkit-box;display:-ms-flexbox;display:flex;margin-bottom:4px}.node--view-mode-teaser .job-listing__title{--line-height: 1.3;font-size:1.25rem;font-weight:500;line-height:var(--line-height);margin-top:0}@media(min-width: 992px){.node--view-mode-teaser .job-listing__title{--line-height: 1.1666666667;font-size:1.5rem;font-weight:500}}.node--view-mode-teaser .job-listing__title a{display:block;text-decoration:none}.node--view-mode-teaser .job-listing__title a:focus,.node--view-mode-teaser .job-listing__title a:hover{text-decoration:underline}.node--view-mode-teaser .job-listing__title a::after{content:"";top:0;right:0;bottom:0;left:0;position:absolute;z-index:2}.node--view-mode-teaser .content-tags{margin-top:16px}.node--view-mode-teaser .job-listing__organization-name{margin-top:8px}.node--view-mode-teaser .job-listing__metadata--application-ends{margin-bottom:24px;margin-top:16px}@media(min-width: 992px){.node--view-mode-teaser .job-listing__metadata--application-ends{margin-top:0}}.block--of-interest{background-color:#e5e5e5;padding:80px 0;margin-top:64px;margin-bottom:calc((50px + 48px)*-1)}.block--of-interest .block--of-interest__content-container{max-width:1296px;padding-left:16px;padding-right:16px;margin:auto}@media(min-width: 768px){.block--of-interest .block--of-interest__content-container{max-width:1328px}}@media(min-width: 768px){.block--of-interest .block--of-interest__content-container{padding-left:32px;padding-right:32px}}.block--of-interest h2{margin-bottom:48px;margin-top:0}
+/* Content is created after this point */
+.job-listing__organization-name {
+  --DEBUG-FONT-TOKEN: "body";
+  --line-height: 1.5555555556;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: var(--line-height);
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-top: 16px;
+}
+@media (min-width: 768px) {
+  .job-listing__organization-name {
+    margin-top: 24px;
+  }
+}
+
+.organization {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 8px;
+  position: relative;
+}
+.organization::after {
+  content: ",";
+}
+.organization:last-child {
+  margin-right: 0;
+}
+.organization:last-child::after {
+  display: none;
+}
+
+.job-listing__link {
+  margin-top: 16px;
+  width: 100%;
+}
+@media (min-width: 768px) {
+  .job-listing__link {
+    margin-top: 24px;
+    width: auto;
+  }
+}
+.job-listing__link:last-of-type {
+  margin-top: 32px;
+}
+@media (min-width: 768px) {
+  .job-listing__link:last-of-type {
+    margin-top: 48px;
+  }
+}
+
+.job-listing__job-description {
+  --DEBUG-FONT-TOKEN: "body";
+  --line-height: 1.5555555556;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: var(--line-height);
+  margin-top: 16px;
+}
+@media (min-width: 768px) {
+  .job-listing__job-description {
+    margin-top: 48px;
+  }
+}
+.job-listing__job-description p:first-child {
+  margin-top: 0;
+}
+
+.job-listing__salary-class__content {
+  --DEBUG-FONT-TOKEN: "body";
+  --line-height: 1.5555555556;
+  font-size: 1.125rem;
+  font-weight: 400;
+  line-height: var(--line-height);
+}
+
+.job-listing__sidebar {
+  background-color: var(--hdbt-color-palette--secondary);
+}
+
+.job-listing__organization-information {
+  padding: 24px;
+}
+
+.job-listing__image img {
+  display: block;
+  height: auto;
+  max-width: 100%;
+  overflow: hidden;
+}
+.job-listing__image .image-placeholder {
+  padding-bottom: 66.67%;
+}
+
+.job-listing__organization {
+  --DEBUG-FONT-TOKEN: "h6";
+  --line-height: 1.5;
+  font-size: 1rem;
+  font-weight: 700;
+  line-height: var(--line-height);
+  margin-top: 0;
+}
+@media (min-width: 992px) {
+  .job-listing__organization {
+    --line-height: 1.5555555556;
+    font-size: 1.125rem;
+    font-weight: 700;
+  }
+}
+
+.job-listing__organization-description {
+  --DEBUG-FONT-TOKEN: "small";
+  --line-height: 1.5;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: var(--line-height);
+  margin-top: 8px;
+}
+.job-listing__organization-description p:first-child {
+  margin-top: 0;
+}
+
+.node--type-job-listing .component--remote-video {
+  margin-top: 32px;
+}
+@media (min-width: 992px) {
+  .node--type-job-listing .component--remote-video {
+    margin-top: 48px;
+  }
+}
+
+.node--view-mode-full .content-tags {
+  margin-top: 24px;
+}
+
+.node--view-mode-teaser {
+  position: relative;
+  padding: 32px;
+  background-color: #ffffff;
+  margin-bottom: 24px;
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+      -ms-flex-direction: column;
+          flex-direction: column;
+}
+.node--view-mode-teaser:hover .hel-icon--arrow-right {
+  -webkit-transform: translateX(4px);
+          transform: translateX(4px);
+}
+@media (prefers-reduced-motion) {
+  .node--view-mode-teaser:hover .hel-icon--arrow-right {
+    -webkit-transform: none;
+            transform: none;
+  }
+}
+@media (min-width: 992px) {
+  .node--view-mode-teaser {
+    -webkit-box-orient: horizontal;
+    -webkit-box-direction: normal;
+        -ms-flex-direction: row;
+            flex-direction: row;
+  }
+}
+@media (min-width: 992px) {
+  .node--view-mode-teaser .job-listing__container-left {
+    width: 70%;
+    padding-right: 32px;
+  }
+}
+.node--view-mode-teaser .job-listing__container-right {
+  position: relative;
+  padding-right: 48px;
+}
+@media (min-width: 992px) {
+  .node--view-mode-teaser .job-listing__container-right {
+    width: 30%;
+  }
+}
+.node--view-mode-teaser .job-listing__container-right .hel-icon {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 32px;
+  height: 32px;
+  -webkit-transition: -webkit-transform 0.2s linear;
+  transition: -webkit-transform 0.2s linear;
+  transition: transform 0.2s linear;
+  transition: transform 0.2s linear, -webkit-transform 0.2s linear;
+}
+@media (prefers-reduced-motion) {
+  .node--view-mode-teaser .job-listing__container-right .hel-icon {
+    -webkit-transition: none;
+    transition: none;
+  }
+}
+.node--view-mode-teaser .job-listing__metadata {
+  width: 100%;
+}
+.node--view-mode-teaser .job-listing__metadata__label {
+  display: -webkit-box;
+  display: -ms-flexbox;
+  display: flex;
+  margin-bottom: 4px;
+}
+.node--view-mode-teaser .job-listing__title {
+  --DEBUG-FONT-TOKEN: "h4";
+  --line-height: 1.3;
+  font-size: 1.25rem;
+  font-weight: 500;
+  line-height: var(--line-height);
+  margin-top: 0;
+}
+@media (min-width: 992px) {
+  .node--view-mode-teaser .job-listing__title {
+    --line-height: 1.1666666667;
+    font-size: 1.5rem;
+    font-weight: 500;
+  }
+}
+.node--view-mode-teaser .job-listing__title a {
+  display: block;
+  text-decoration: none;
+}
+.node--view-mode-teaser .job-listing__title a:focus, .node--view-mode-teaser .job-listing__title a:hover {
+  text-decoration: underline;
+}
+.node--view-mode-teaser .job-listing__title a::after {
+  content: "";
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  z-index: 2;
+}
+.node--view-mode-teaser .content-tags {
+  margin-top: 16px;
+}
+.node--view-mode-teaser .job-listing__organization-name {
+  margin-top: 8px;
+}
+.node--view-mode-teaser .job-listing__metadata--application-ends {
+  margin-bottom: 24px;
+  margin-top: 16px;
+}
+@media (min-width: 992px) {
+  .node--view-mode-teaser .job-listing__metadata--application-ends {
+    margin-top: 0;
+  }
+}
+
+.block--of-interest {
+  background-color: #e5e5e5;
+  padding: 80px 0;
+  margin-top: 64px;
+  margin-bottom: calc((50px + 48px) * -1);
+}
+.block--of-interest .block--of-interest__content-container {
+  max-width: 1296px;
+  padding-left: 16px;
+  padding-right: 16px;
+  margin: auto;
+}
+@media (min-width: 768px) {
+  .block--of-interest .block--of-interest__content-container {
+    max-width: 1328px;
+  }
+}
+@media (min-width: 768px) {
+  .block--of-interest .block--of-interest__content-container {
+    padding-left: 32px;
+    padding-right: 32px;
+  }
+}
+.block--of-interest h2 {
+  margin-bottom: 48px;
+  margin-top: 0;
+}
+
+/*# sourceMappingURL=styles.min.css.map*/

--- a/public/themes/custom/hdbt_subtheme/dist/js/common.min.js
+++ b/public/themes/custom/hdbt_subtheme/dist/js/common.min.js
@@ -1,1 +1,33 @@
-((t,a)=>{t.behaviors.themeCommon={attach:function(){}}})(Drupal,drupalSettings);
+/*
+ * ATTENTION: An "eval-source-map" devtool has been used.
+ * This devtool is neither made for production nor for readable output files.
+ * It uses "eval()" calls to create a separate source file with attached SourceMaps in the browser devtools.
+ * If you are trying to read the output file, select a different devtool (https://webpack.js.org/configuration/devtool/)
+ * or disable the default devtool with "devtool: false".
+ * If you are looking for production-ready output files, see mode: "production" (https://webpack.js.org/configuration/mode/).
+ */
+/******/ (function() { // webpackBootstrap
+/******/ 	var __webpack_modules__ = ({
+
+/***/ "./src/js/common.js":
+/*!**************************!*\
+  !*** ./src/js/common.js ***!
+  \**************************/
+/***/ (function() {
+
+eval("// eslint-disable-next-line no-unused-vars\n((Drupal, drupalSettings) => {\n  Drupal.behaviors.themeCommon = {\n    attach: function attach() {// Code here.\n    }\n  }; // eslint-disable-next-line no-undef\n})(Drupal, drupalSettings);//# sourceURL=[module]\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJzb3VyY2VzIjpbIndlYnBhY2s6Ly9oZGJ0X3N1YnRoZW1lLy4vc3JjL2pzL2NvbW1vbi5qcz80NDBhIl0sIm5hbWVzIjpbIkRydXBhbCIsImRydXBhbFNldHRpbmdzIiwiYmVoYXZpb3JzIiwidGhlbWVDb21tb24iLCJhdHRhY2giXSwibWFwcGluZ3MiOiJBQUFBO0FBQ0EsQ0FBQyxDQUFDQSxNQUFELEVBQVNDLGNBQVQsS0FBNEI7QUFDM0JELEVBQUFBLE1BQU0sQ0FBQ0UsU0FBUCxDQUFpQkMsV0FBakIsR0FBK0I7QUFDN0JDLElBQUFBLE1BQU0sRUFBRSxTQUFTQSxNQUFULEdBQWtCLENBQ3hCO0FBQ0Q7QUFINEIsR0FBL0IsQ0FEMkIsQ0FNM0I7QUFDRCxDQVBELEVBT0dKLE1BUEgsRUFPV0MsY0FQWCIsInNvdXJjZXNDb250ZW50IjpbIi8vIGVzbGludC1kaXNhYmxlLW5leHQtbGluZSBuby11bnVzZWQtdmFyc1xuKChEcnVwYWwsIGRydXBhbFNldHRpbmdzKSA9PiB7XG4gIERydXBhbC5iZWhhdmlvcnMudGhlbWVDb21tb24gPSB7XG4gICAgYXR0YWNoOiBmdW5jdGlvbiBhdHRhY2goKSB7XG4gICAgICAvLyBDb2RlIGhlcmUuXG4gICAgfSxcbiAgfTtcbiAgLy8gZXNsaW50LWRpc2FibGUtbmV4dC1saW5lIG5vLXVuZGVmXG59KShEcnVwYWwsIGRydXBhbFNldHRpbmdzKTtcbiJdLCJmaWxlIjoiLi9zcmMvanMvY29tbW9uLmpzLmpzIiwic291cmNlUm9vdCI6IiJ9\n//# sourceURL=webpack-internal:///./src/js/common.js\n");
+
+/***/ })
+
+/******/ 	});
+/************************************************************************/
+/******/ 	
+/******/ 	// startup
+/******/ 	// Load entry module and return exports
+/******/ 	// This entry module can't be inlined because the eval-source-map devtool is used.
+/******/ 	var __webpack_exports__ = {};
+/******/ 	__webpack_modules__["./src/js/common.js"]();
+/******/ 	
+/******/ })()
+;
+//# sourceMappingURL=common.min.js.map

--- a/public/themes/custom/hdbt_subtheme/src/scss/06_components/pages/_job-listing.scss
+++ b/public/themes/custom/hdbt_subtheme/src/scss/06_components/pages/_job-listing.scss
@@ -71,11 +71,17 @@
   padding: $spacing-and-half;
 }
 
-.job-listing__image img {
-  display: block;
-  height: auto;
-  max-width: 100%;
-  overflow: hidden;
+.job-listing__image {
+  img {
+    display: block;
+    height: auto;
+    max-width: 100%;
+    overflow: hidden;
+  }
+
+  .image-placeholder {
+    padding-bottom: 66.67%; // 3:2 aspect ratio.
+  }
 }
 
 .job-listing__organization {
@@ -132,7 +138,7 @@
   }
 
   .job-listing__container-right {
-    position: relative; 
+    position: relative;
     padding-right: $spacing-triple;
 
     @include breakpoint($breakpoint-l) {
@@ -168,12 +174,12 @@
   .job-listing__title a {
     display: block;
     text-decoration: none;
-  
+
     &:focus,
     &:hover {
       text-decoration: underline;
     }
-  
+
     &::after {
       content: '';
       inset: 0;


### PR DESCRIPTION
# [UHF-5991](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5991)
<!-- What problem does this solve? -->
Organizations have default pictures that can be added to the taxonomy term "Organization". They were not used in the job applications but this branch adds the feature to them.

## What was done
<!-- Describe what was done -->
* Added logic that checks if the organization default picture is set and prints it on the job application if one is provided unless the job application has its own "Picture" field filled.
* Changed the picture and the organization default picture to use same image style.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout origin UHF-5991_organization_default_images`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to edit two organization terms here: https://helfi-rekry.docker.so/fi/admin/structure/taxonomy/manage/organization/overview and make sure one of them doesn't have default picture set and that one of them has a default picture set.
* [x] Now go to edit a job application node. Any will do. Make sure that there is no picture set for that job application.
* [x] Select the organization that doesn't have any default picture set and save the node. The picture on the sidebar of the node should be default icon with background color.
* [x] Edit the node again and select the organization that has default picture set and save the node. The picture on the sidebar of the node should be the default picture that you set for the organization.
* [x] Edit the node again and add a picture to the job application and save the node. The picture on the sidebar of the node should be the one you just added.
* [ ] Check that code follows our standards.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Sami Haikonen)