### PR TITLE
UHF-5986: Unpublish job listings that are no longer available at source

### DIFF
--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.services.yml
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.services.yml
@@ -5,8 +5,13 @@ services:
       - { name: 'event_subscriber' }
   Drupal\helfi_rekry_content\Plugin\Deriver:
     arguments: ['@config.factory']
+  helfi_rekry_content.job_listing_hide_missing:
+    class: Drupal\helfi_rekry_content\EventSubscriber\JobListingHideMissingSubscriber
+    arguments: [ '@entity_type.manager' ]
+    tags:
+      - { name: 'event_subscriber' }
   helfi_rekry_content.job_listing_redirect_subscriber:
     class: Drupal\helfi_rekry_content\EventSubscriber\JobListingRedirectSubscriber
     arguments: ['@config.factory', '@current_user']
     tags:
-      - { name: event_subscriber }
+      - { name: 'event_subscriber' }

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingHideMissingSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingHideMissingSubscriber.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_rekry_content\EventSubscriber;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\migrate\Event\MigrateEvents;
+use Drupal\migrate\Event\MigrateImportEvent;
+use Drupal\node\NodeInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Subscribe to job listing import events for hiding missing items.
+ */
+class JobListingHideMissingSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a new JobListingHideMissingSubscriber object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {}
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      MigrateEvents::PRE_IMPORT => 'hideMissingJobListings',
+    ];
+  }
+
+  /**
+   * Unpublish job listings that are no longer available at the API.
+   *
+   * @param \Drupal\migrate\Event\MigrateImportEvent $event
+   *   The migration import event.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   * @throws \Drupal\Core\Entity\EntityStorageException
+   */
+  public function hideMissingJobListings(MigrateImportEvent $event): void {
+    // Return early if the migration is not a job listing migration.
+    if (!in_array($event->getMigration()->id(), $this->getJobListingMigrations())) {
+      return;
+    }
+
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+    /** @var \Drupal\migrate\Plugin\migrate\id_map\Sql $idMap */
+    $idMap = $event->getMigration()->getIdMap();
+    // Mark all previously imported as ready to be re-imported in order to have
+    // a full list of source IDs.
+    $idMap->prepareUpdate();
+
+    /** @var \Drupal\migrate_plus\Plugin\migrate\source\Url $source */
+    $source = clone $event->getMigration()->getSourcePlugin();
+    $source->rewind();
+    $sourceIdValues = [];
+
+    // Get source IDs from the current source.
+    while ($source->valid()) {
+      $sourceIdValues[] = $source->current()->getSourceIdValues();
+      $source->next();
+    }
+
+    // Iterate existing migration rows.
+    $idMap->rewind();
+    while ($idMap->valid()) {
+      // Get current source ID and ID for the existing node.
+      $mapSourceId = $idMap->currentSource();
+      $destinationIds = $idMap->currentDestination();
+
+      if (!in_array($mapSourceId, $sourceIdValues, TRUE) && !empty($destinationIds['nid'])) {
+        // The job listing row is no longer found from source.
+        $node = $nodeStorage->load($destinationIds['nid']);
+        if ($node instanceof NodeInterface && $node->getType() == 'job_listing' && $node->isPublished()) {
+          // Unpublish the job listing node as it's still published, but its
+          // source is no longer available.
+          $node->setUnpublished();
+          $node->save();
+        }
+      }
+
+      $idMap->next();
+    }
+  }
+
+  /**
+   * Return all possible job listing migrations.
+   *
+   * @return array
+   *   The migration names.
+   */
+  protected function getJobListingMigrations(): array {
+    return [
+      'helfi_rekry_jobs',
+      'helfi_rekry_jobs:all',
+      'helfi_rekry_jobs:all_en',
+      'helfi_rekry_jobs:all_sv',
+    ];
+  }
+
+}


### PR DESCRIPTION
# [UHF-5986](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5986)

Hides job listings that are no longer available at the source API.

## What was done
* Added event subscriber to unpublish job listings at the pre-import step.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-5986-hide-job-listing-not-in-api`
  * `make fresh`
* Run `make drush-cr`

## How to test
* Find a job listing that's no longer at the API.
* Publish the job listing.
* Check that the job listing is unpublished after the import, e.g.
  * `helfi_rekry_jobs:all`
* [x] Check that this feature works
* [x] Check that code follows our standards

## Designers review

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
