### PR TITLE
UHF-5290: Organization description

### DIFF
--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -239,3 +239,47 @@ function template_preprocess_organization_information_block(array &$variables) :
   ]);
   $variables['content']['organization_default_image'] = $organization_default_image;
 }
+
+/**
+ * Implements hook_page_attachments_alter().
+ */
+function helfi_rekry_content_page_attachments_alter(array &$attachments) : void {
+  $node = \Drupal::routeMatch()->getParameter('node');
+
+  if ($node instanceof \Drupal\node\NodeInterface && $node->bundle() == 'job_listing') {
+    $image_uri = FALSE;
+
+    // If the node has an image, use that.
+    if ($node->hasField('field_image') && !$node->field_image->isEmpty()) {
+      $image_uri = $node->field_image->entity->field_media_image->entity->getFileUri();
+    }
+    else {
+      // Otherwise, use the one from the taxonomy term.
+      $taxonomy_term = $node->field_organization->entity;
+
+      if ($taxonomy_term->hasField('field_default_image') && !$taxonomy_term->field_default_image->isEmpty()) {
+        $image_uri = $taxonomy_term->field_default_image->entity->getFileUri();
+      }
+    }
+
+    if ($image_uri) {
+      // Replace the default og:image tag.
+      $og_image_url = \Drupal::service('file_url_generator')->generateAbsoluteString($image_uri);
+
+      $og_image = [
+        '#tag' => 'meta',
+        '#attributes' => [
+          'property' => 'og:image',
+          'content' => $og_image_url,
+        ],
+      ];
+
+      foreach ($attachments['#attached']['html_head'] as $key => $value) {
+        if (isset($value[0]['#attributes']['property']) && $value[0]['#attributes']['property'] == 'og:image') {
+          $attachments['#attached']['html_head'][$key] = [$og_image, 'og:image'];
+          break;
+        }
+      }
+    }
+  }
+}

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -246,7 +246,7 @@ function template_preprocess_organization_information_block(array &$variables) :
 function helfi_rekry_content_page_attachments_alter(array &$attachments) : void {
   $node = \Drupal::routeMatch()->getParameter('node');
 
-  if ($node instanceof \Drupal\node\NodeInterface && $node->bundle() == 'job_listing') {
+  if ($node instanceof NodeInterface && $node->bundle() == 'job_listing') {
     $image_uri = FALSE;
 
     // If the node has an image, use that.


### PR DESCRIPTION
UHF-5290: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5290

Pretty much all the functionality described in the ticket was already implemented in other tasks.

## What was done

- Using the node image as the `og:image` tag. If the node does not have an image, using the one in the linked taxonomy term.

## How to install

1. Set up REKRY instance
2. Get this branch: `git checkout UHF-5290_organization_description`

## How to test

- Edit any job listing node and add an image. Save the node and check that the `og:image` tag in the source points to that image URL.
- Remove the image from the node and edit the related organization taxonomy term. Add an image to the term and save it. View the node source and check that the `og:image` now points to that image URL.

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
