### PR TITLE
UHF-6560: Show number of vacancies

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -73,6 +73,29 @@ function hdbt_subtheme_preprocess_organization_information_block(array &$variabl
 }
 
 /**
+ * Implements hook_preprocess_HOOK().
+ *
+ * Adds number of open vacancies for job listing title field template.
+ *
+ * @throws \Drupal\Core\TypedData\Exception\MissingDataException
+ */
+function hdbt_subtheme_preprocess_field(&$variables): void {
+  // Return yearly if not processing job listing title.
+  if (
+    $variables['field_name'] != 'title' ||
+    $variables['element']['#entity_type'] != 'node' ||
+    $variables['element']['#bundle'] != 'job_listing'
+  ) {
+    return;
+  }
+
+  if ($node = $variables['element']['#object']) {
+    /** @var \Drupal\node\NodeInterface $node */
+    $variables['vacancies'] = (int) $node->get('field_jobs')?->first()?->getString();
+  }
+}
+
+/**
  * Implements hook_theme_suggestions_HOOK() for blocks.
  */
 function hdbt_subtheme_theme_suggestions_block_alter(&$suggestions) {

--- a/public/themes/custom/hdbt_subtheme/templates/field/field--node--title--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/field/field--node--title--job-listing.html.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Theme override for the job listing node title field.
+ *
+ * Added variable:
+ * - vacancies: The number of open jobs for the job listing.
+ *
+ * @see field.html.twig
+ */
+#}
+{% if not is_inline %}
+  {% include "field.html.twig" %}
+{% else %}
+<span{{ attributes }}>
+  {%- for item in items -%}
+    {{ item.content }}{% if vacancies > 1 %} ({{ vacancies }} jobs){% endif %}
+  {%- endfor -%}
+</span>
+{% endif %}

--- a/public/themes/custom/hdbt_subtheme/templates/field/field--node--title--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/field/field--node--title--job-listing.html.twig
@@ -14,7 +14,7 @@
 {% else %}
 <span{{ attributes }}>
   {%- for item in items -%}
-    {{ item.content }}{% if vacancies > 1 %} ({{ vacancies }} jobs){% endif %}
+    {{ item.content }}{% if vacancies > 1 %} ({{ vacancies }} {{ 'jobs'|t }}){% endif %}
   {%- endfor -%}
 </span>
 {% endif %}

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -1,3 +1,6 @@
-# Swedish translations
+# Finnish translations
 msgid ""
 msgstr ""
+
+msgid "jobs"
+msgstr "tehtävää"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -1,3 +1,6 @@
-# Finnish translations
+# Swedish translations
 msgid ""
 msgstr ""
+
+msgid "jobs"
+msgstr "jobb"


### PR DESCRIPTION
# [UHF-6560](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6560)

## What was done
* Now the number of vacancies are shown after the job listing title in the cases where there are at least two open vacancies.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6560-show-number-of-vacancies`
  * `make fresh`
* Run `make shell` and then:
  * `drush locale:import fi /app/public/themes/custom/hdbt_subtheme/translations/fi.po`
  * `drush locale:import sv /app/public/themes/custom/hdbt_subtheme/translations/sv.po`
  * `drush cr`

## How to test
* Go to a job listing page.
* Edit the page's `Jobs` field so that you can test the following cases:
  * If there is no value or if the value is smaller than 2, no extra info after the title is shown.
  * If there are 2 or more vacancies, the information is shown after the title.

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
