### PR TITLE
UHF-6559: Show link_to_presentation field at job listing page

### DIFF
--- a/conf/cmi/core.entity_view_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.default.yml
@@ -79,7 +79,7 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 13
+    weight: 14
     region: content
   field_job_duration:
     type: string
@@ -101,20 +101,32 @@ content:
     third_party_settings: {  }
     weight: 3
     region: content
+  field_link_to_presentation:
+    type: link
+    label: hidden
+    settings:
+      trim_length: 80
+      url_only: true
+      url_plain: false
+      rel: '0'
+      target: '0'
+    third_party_settings: {  }
+    weight: 13
+    region: content
   field_organization:
     type: entity_reference_label
     label: hidden
     settings:
       link: false
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: content
   field_organization_description:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 16
+    weight: 17
     region: content
   field_organization_name:
     type: string
@@ -171,7 +183,7 @@ content:
       view_mode: default
       link: true
     third_party_settings: {  }
-    weight: 15
+    weight: 16
     region: content
   job_description:
     type: text_default
@@ -184,7 +196,6 @@ hidden:
   field_anonymous: true
   field_jobs: true
   field_last_changed_remote: true
-  field_link_to_presentation: true
   field_prevent_publishing: true
   field_recruitment_type: true
   field_task_area: true

--- a/public/themes/custom/hdbt_subtheme/templates/field/field--field-link-to-presentation.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/field/field--field-link-to-presentation.html.twig
@@ -1,0 +1,7 @@
+{% for item in items %}
+  {% set link_title %}{{ item.content['#url'].uri }}{% endset %}
+  {% set link_attributes = {
+    'data-selected-icon': 'link',
+  } %}
+  {{ link(link_title, item.content['#url'].uri, link_attributes) }}
+{% endfor %}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -138,12 +138,12 @@
 
         {{ content.job_description }}
         {{ content.field_salary_class }}
-        {% if content.field_contacts|render or content.field_internet_link %}
+        {% if content.field_contacts|render or content.field_link_to_presentation|render %}
           <div class="job-listing__additional-information">
             <h2 class="job-listing__additional-information__title">{{ 'Additional information'|t }}</h2>
             <div class="job-listing__additional-information__content">
               {{ content.field_contacts }}
-              {{ content.field_internet_link }}
+              {{ content.field_link_to_presentation }}
             </div>
           </div>
         {% endif %}


### PR DESCRIPTION
# [UHF-6559](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6559)

## What was done
* Show link_to_presentation field at job listing page.
  * This field contains data from job listing API's jobAdvertisement/internetLink field.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git pull origin UHF-6559-internet-link-field`
* Run:
  * `make fresh` or 
  * `make drush-cim` and `make drush-cr`

## How to test
* Go to the content listing.
* Open some job listings in editing mode and check at least some of them have content in the `Link to presentation` field.
* Open the job listings in view mode and check that the field is shown at the Additional information section, as shown at the layout (see the ticket).

## Designers review
* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
