### PR TITLE
UHF-6558: Job listing publication start/end fields

### DIFF
--- a/conf/cmi/core.entity_form_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.node.job_listing.default.yml
@@ -20,6 +20,8 @@ dependencies:
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
     - field.field.node.job_listing.field_prevent_publishing
+    - field.field.node.job_listing.field_publication_ends
+    - field.field.node.job_listing.field_publication_starts
     - field.field.node.job_listing.field_recruitment_id
     - field.field.node.job_listing.field_recruitment_type
     - field.field.node.job_listing.field_salary
@@ -34,6 +36,7 @@ dependencies:
     - link
     - media_library
     - path
+    - publication_date
     - scheduler
     - text
 id: node.job_listing.default
@@ -182,6 +185,18 @@ content:
     region: content
     settings:
       display_label: true
+    third_party_settings: {  }
+  field_publication_ends:
+    type: datetime_default
+    weight: 38
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_publication_starts:
+    type: datetime_default
+    weight: 37
+    region: content
+    settings: {  }
     third_party_settings: {  }
   field_recruitment_id:
     type: string_textfield

--- a/conf/cmi/core.entity_view_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.default.yml
@@ -20,6 +20,8 @@ dependencies:
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
     - field.field.node.job_listing.field_prevent_publishing
+    - field.field.node.job_listing.field_publication_ends
+    - field.field.node.job_listing.field_publication_starts
     - field.field.node.job_listing.field_recruitment_id
     - field.field.node.job_listing.field_recruitment_type
     - field.field.node.job_listing.field_salary
@@ -30,6 +32,7 @@ dependencies:
     - image.style.3_2_m_2x
     - node.type.job_listing
   module:
+    - datetime
     - link
     - media
     - text
@@ -152,6 +155,24 @@ content:
     third_party_settings: {  }
     weight: 7
     region: content
+  field_publication_ends:
+    type: datetime_default
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 19
+    region: content
+  field_publication_starts:
+    type: datetime_default
+    label: hidden
+    settings:
+      timezone_override: ''
+      format_type: medium
+    third_party_settings: {  }
+    weight: 18
+    region: content
   field_recruitment_id:
     type: string
     label: hidden
@@ -201,4 +222,5 @@ hidden:
   field_task_area: true
   langcode: true
   links: true
+  published_at: true
   toc_enabled: true

--- a/conf/cmi/core.entity_view_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.default.yml
@@ -160,7 +160,7 @@ content:
     label: hidden
     settings:
       timezone_override: ''
-      format_type: medium
+      format_type: publication_date_format
     third_party_settings: {  }
     weight: 19
     region: content
@@ -169,7 +169,7 @@ content:
     label: hidden
     settings:
       timezone_override: ''
-      format_type: medium
+      format_type: publication_date_format
     third_party_settings: {  }
     weight: 18
     region: content

--- a/conf/cmi/core.entity_view_display.node.job_listing.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.teaser.yml
@@ -21,6 +21,8 @@ dependencies:
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
     - field.field.node.job_listing.field_prevent_publishing
+    - field.field.node.job_listing.field_publication_ends
+    - field.field.node.job_listing.field_publication_starts
     - field.field.node.job_listing.field_recruitment_id
     - field.field.node.job_listing.field_recruitment_type
     - field.field.node.job_listing.field_salary
@@ -80,6 +82,8 @@ hidden:
   field_postal_area: true
   field_postal_code: true
   field_prevent_publishing: true
+  field_publication_ends: true
+  field_publication_starts: true
   field_recruitment_id: true
   field_recruitment_type: true
   field_salary: true
@@ -88,4 +92,5 @@ hidden:
   field_video: true
   job_description: true
   langcode: true
+  published_at: true
   toc_enabled: true

--- a/conf/cmi/field.field.node.job_listing.field_publication_ends.yml
+++ b/conf/cmi/field.field.node.job_listing.field_publication_ends.yml
@@ -11,13 +11,15 @@ dependencies:
 third_party_settings:
   disable_field:
     add_disable: none
-    edit_disable: none
+    edit_disable: roles
+    edit_roles:
+      - hr
 id: node.job_listing.field_publication_ends
 field_name: field_publication_ends
 entity_type: node
 bundle: job_listing
 label: 'Publication ends'
-description: ''
+description: 'Publication end date in remote system (Helbit).'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.node.job_listing.field_publication_ends.yml
+++ b/conf/cmi/field.field.node.job_listing.field_publication_ends.yml
@@ -1,0 +1,26 @@
+uuid: 7e37cb85-4db2-4918-97cd-8039d3c2f86f
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publication_ends
+    - node.type.job_listing
+  module:
+    - datetime
+    - disable_field
+third_party_settings:
+  disable_field:
+    add_disable: none
+    edit_disable: none
+id: node.job_listing.field_publication_ends
+field_name: field_publication_ends
+entity_type: node
+bundle: job_listing
+label: 'Publication ends'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.job_listing.field_publication_ends.yml
+++ b/conf/cmi/field.field.node.job_listing.field_publication_ends.yml
@@ -19,7 +19,7 @@ field_name: field_publication_ends
 entity_type: node
 bundle: job_listing
 label: 'Publication ends'
-description: 'Publication end date in remote system (Helbit).'
+description: 'Publication end date in remote system (Helbit). Does not affect publication status on the site.'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.node.job_listing.field_publication_starts.yml
+++ b/conf/cmi/field.field.node.job_listing.field_publication_starts.yml
@@ -19,7 +19,7 @@ field_name: field_publication_starts
 entity_type: node
 bundle: job_listing
 label: 'Publication starts'
-description: 'Publication start date in remote system (Helbit).'
+description: 'Publication start date in remote system (Helbit). Does not affect publication status on the site.'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.field.node.job_listing.field_publication_starts.yml
+++ b/conf/cmi/field.field.node.job_listing.field_publication_starts.yml
@@ -1,0 +1,26 @@
+uuid: 5e065085-94ce-498c-9ef8-f2e6a42fdfd5
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_publication_starts
+    - node.type.job_listing
+  module:
+    - datetime
+    - disable_field
+third_party_settings:
+  disable_field:
+    add_disable: none
+    edit_disable: none
+id: node.job_listing.field_publication_starts
+field_name: field_publication_starts
+entity_type: node
+bundle: job_listing
+label: 'Publication starts'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/conf/cmi/field.field.node.job_listing.field_publication_starts.yml
+++ b/conf/cmi/field.field.node.job_listing.field_publication_starts.yml
@@ -11,13 +11,15 @@ dependencies:
 third_party_settings:
   disable_field:
     add_disable: none
-    edit_disable: none
+    edit_disable: roles
+    edit_roles:
+      - hr
 id: node.job_listing.field_publication_starts
 field_name: field_publication_starts
 entity_type: node
 bundle: job_listing
 label: 'Publication starts'
-description: ''
+description: 'Publication start date in remote system (Helbit).'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.storage.node.field_publication_ends.yml
+++ b/conf/cmi/field.storage.node.field_publication_ends.yml
@@ -1,0 +1,20 @@
+uuid: ed69c88c-c9d0-4692-9301-11219b5369f8
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_publication_ends
+field_name: field_publication_ends
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_publication_starts.yml
+++ b/conf/cmi/field.storage.node.field_publication_starts.yml
@@ -1,0 +1,20 @@
+uuid: 6193f566-a5f7-4597-8d7d-710c5f85fedf
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - node
+id: node.field_publication_starts
+field_name: field_publication_starts
+entity_type: node
+type: datetime
+settings:
+  datetime_type: datetime
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.node.job_listing.field_publication_ends.yml
+++ b/conf/cmi/language/fi/field.field.node.job_listing.field_publication_ends.yml
@@ -1,0 +1,2 @@
+label: 'Julkaisun päättyminen'
+description: 'Julkaisun päättymisajankohta Helbitissä. Ei vaikuta ilmoituksen julkaisun tilaan sivustolla.'

--- a/conf/cmi/language/fi/field.field.node.job_listing.field_publication_starts.yml
+++ b/conf/cmi/language/fi/field.field.node.job_listing.field_publication_starts.yml
@@ -1,0 +1,2 @@
+label: 'Julkaisun alkaminen'
+description: 'Julkaisun alkamisajankohta Helbitissä. Ei vaikuta ilmoituksen julkaisun tilaan sivustolla.'

--- a/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
@@ -229,5 +229,7 @@ process:
     plugin: callback
     callable: strtotime
     source: publication_ends
+  field_publication_starts: publication_starts
+  field_publication_ends: publication_ends
 destination:
   plugin: 'entity:node'

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -153,3 +153,21 @@ function hdbt_subtheme_preprocess_page(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_node().
+ */
+function hdbt_subtheme_preprocess_node(&$variables) {
+  $node = $variables['node'];
+
+  if ($node->getType() == 'job_listing') {
+    // Check if job listing publication starts today.
+    $variables['publication_starts_today'] = FALSE;
+
+    $publication_starts_value = $node->get('field_publication_starts')->value;
+
+    if (date('Y-m-d', strtotime($publication_starts_value)) == date('Y-m-d')) {
+      $variables['publication_starts_today'] = TRUE;
+    }
+  }
+}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -124,7 +124,7 @@
         {{ content.field_organization_name }}
         {{ content.field_link_to_application }}
 
-        {% if content.field_publication_starts.0['#attributes']['datetime']|date('Y-m-d') == 'now'|date('Y-m-d') %}
+        {% if publication_starts_today == true %}
           {% set publication_starts = 'today'|t %}
         {% else %}
           {% set publication_starts = content.field_publication_starts %}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -62,6 +62,8 @@
  *   current user is a logged-in member.
  * - is_admin: Flag for admin user status. Will be true when the current user
  *   is an administrator.
+ * - publication_starts_today: Helper variable for displaying 'today' instead
+ *   of the actual timestamp if the job listing is published today.
  *
  * @see template_preprocess_node()
  *

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -124,7 +124,7 @@
         {{ content.field_organization_name }}
         {{ content.field_link_to_application }}
 
-        {% if content.field_publication_starts.value|date() == 'now'|date() %}
+        {% if content.field_publication_starts.0['#attributes']['datetime']|date('Y-m-d') == 'now'|date('Y-m-d') %}
           {% set publication_starts = 'today'|t %}
         {% else %}
           {% set publication_starts = content.field_publication_starts %}

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -123,12 +123,19 @@
         {% endif %}
         {{ content.field_organization_name }}
         {{ content.field_link_to_application }}
+
+        {% if content.field_publication_starts.value|date() == 'now'|date() %}
+          {% set publication_starts = 'today'|t %}
+        {% else %}
+          {% set publication_starts = content.field_publication_starts %}
+        {% endif %}
+
         {% set metadata = [
-          { label: 'Application ends'|t, icon: 'clock', content: unpublish_on },
+          { label: 'Application ends'|t, icon: 'clock', content: content.field_publication_ends },
           { label: 'Salary'|t, icon: 'glyph-euro', content: content.field_salary },
           { label: 'Employment contract'|t, icon: 'calendar', content: content.field_job_duration },
           { label: 'Address'|t, icon: 'location', content: [content.field_address, content.field_postal_code, content.field_postal_area] },
-          { label: 'Published'|t, icon: 'calendar-clock', content: content.field_publication_starts },
+          { label: 'Published'|t, icon: 'calendar-clock', content: publication_starts },
           { label: 'Job code'|t, icon: 'locate', content: content.field_recruitment_id },
         ] %}
 

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -4,3 +4,6 @@ msgstr ""
 
 msgid "jobs"
 msgstr "tehtävää"
+
+msgid "today"
+msgstr "tänään"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -4,3 +4,6 @@ msgstr ""
 
 msgid "jobs"
 msgstr "jobb"
+
+msgid "today"
+msgstr "idag"


### PR DESCRIPTION
# [UHF-6558](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6558)

## What was done
- added new fields for publication start and end times
- importing corresponding timestamps from the API to the new fields
- displaying the dates from the new fields instead of the node scheduler fields
- showing "today" as publication date if the job listing is set to be published on the current day
- added Finnish and Swedish translations for the word "today"

## How to install
1. set up REKRY instance
2. checkout this branch: `git checkout UHF-6558_publication_start_end_fields`
3. import config: `make drush-cim`
4. import translations: `make shell` and then `drush locale:check; drush locale:update; drush cr`

## How to test
1. run the job listing migration: `HELBIT_CLIENT_ID=<ask in slack> drush migrate:import helfi_rekry_jobs:all`
2. open any job listing and see that the dates match the ones in the fields
3. edit the publication start date to today and save the node, then see if "today" is displayed instead of the date
4. see that the translations work

## Designers review

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
