### PR TITLE
UHF-6676 Calculoid test

### DIFF
--- a/conf/cmi/block.block.calculoidjavascript.yml
+++ b/conf/cmi/block.block.calculoidjavascript.yml
@@ -1,0 +1,25 @@
+uuid: 41aff990-6ae3-417c-b5fa-ed4270ba173c
+langcode: fi
+status: true
+dependencies:
+  module:
+    - helfi_rekry_content
+    - system
+  theme:
+    - hdbt_subtheme
+id: calculoidjavascript
+theme: hdbt_subtheme
+region: content
+weight: 1
+provider: null
+plugin: calculoid_javascript_block
+settings:
+  id: calculoid_javascript_block
+  label: 'Calculoid Javascript'
+  label_display: '0'
+  provider: helfi_rekry_content
+visibility:
+  request_path:
+    id: request_path
+    negate: false
+    pages: /kotihoidon-asiakasmaksulaskuri

--- a/conf/cmi/block.block.calculoidjavascript.yml
+++ b/conf/cmi/block.block.calculoidjavascript.yml
@@ -1,5 +1,5 @@
 uuid: 41aff990-6ae3-417c-b5fa-ed4270ba173c
-langcode: fi
+langcode: en
 status: true
 dependencies:
   module:

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -191,5 +191,10 @@ function helfi_rekry_content_theme() {
     'organization_information_block' => [
       'render element' => 'elements',
     ],
+    'calculoid_javascript_block' => [
+      'variables' => [
+        'data' => [],
+      ],
+    ],
   ];
 }

--- a/public/modules/custom/helfi_rekry_content/src/Plugin/Block/CalculoidJavascript.php
+++ b/public/modules/custom/helfi_rekry_content/src/Plugin/Block/CalculoidJavascript.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Drupal\helfi_rekry_content\Plugin\Block;
+
+use Drupal\Core\Block\BlockBase;
+
+/**
+ * Provides a 'CalculoidJavascript' Block.
+ *
+ * @Block(
+ *   id = "calculoid_javascript_block",
+ *   admin_label = @Translation("Calculoid Javascript"),
+ *   category = @Translation("Calculoid Javascript"),
+ * )
+ */
+class CalculoidJavascript extends BlockBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function build() {
+    return [
+      '#theme' => 'calculoid_javascript_block',
+    ];
+  }
+
+}

--- a/public/modules/custom/helfi_rekry_content/templates/calculoid-javascript-block.html.twig
+++ b/public/modules/custom/helfi_rekry_content/templates/calculoid-javascript-block.html.twig
@@ -1,3 +1,13 @@
-<link rel="stylesheet" href="https://embed.calculoid.com/styles/main.css" />
-<script src="https://embed.calculoid.com/scripts/combined.min.js"></script>
-<div ng-app="calculoid" ng-controller="CalculoidMainCtrl" ng-init="init({calcId:95057,apiKey:'1793b4f862a70d09aad19'})" ng-include="load()"></div>
+{% block paragraph %}
+	{% embed "@hdbt/misc/component.twig" with
+    {
+      component_classes: [ 'component--calculoid-javascript' ],
+    }
+  %}
+		{% block component_content %}
+      <link rel="stylesheet" href="https://embed.calculoid.com/styles/main.css" />
+      <script src="https://embed.calculoid.com/scripts/combined.min.js"></script>
+      <div ng-app="calculoid" ng-controller="CalculoidMainCtrl" ng-init="init({calcId:97095,apiKey:'2bd1291663564ac8c1247',showTitle:0,showDescription:0})" ng-include="load()"></div>
+    {% endblock component_content %}
+  {% endembed %}
+{% endblock paragraph %}

--- a/public/modules/custom/helfi_rekry_content/templates/calculoid-javascript-block.html.twig
+++ b/public/modules/custom/helfi_rekry_content/templates/calculoid-javascript-block.html.twig
@@ -1,0 +1,3 @@
+<link rel="stylesheet" href="https://embed.calculoid.com/styles/main.css" />
+<script src="https://embed.calculoid.com/scripts/combined.min.js"></script>
+<div ng-app="calculoid" ng-controller="CalculoidMainCtrl" ng-init="init({calcId:95057,apiKey:'1793b4f862a70d09aad19'})" ng-include="load()"></div>


### PR DESCRIPTION
# [UHF-6676](https://helsinkisolutionoffice.atlassian.net/browse/UHF-6676)
<!-- What problem does this solve? -->
Adds testing custom block for evaluating the applicability of Calculoid service.

## What was done
<!-- Describe what was done -->

* A custom block called Calculoid Javascript was created that embeds custom calculator from Calculoid service.
* The block is added to content area and visible only on path `/kotihoidon-asiakasmaksulaskuri`

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch`
  * `git checkout UHF-6676_calculoid_test`
  * `make fresh`
* Run `make drush-cim && make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to create a new standard page and give it title: `Kotihoidon asiakasmaksulaskuri`. This should make sure the alias of the page results into `/kotihoidon-asiakasmaksulaskuri` but incase it doesn't then change it to that format.
* [ ] Add some ingress and text content on the page and save it.
* [ ] The calculoid calculator should now appear under the content and work correctly.
* [ ] Check that this implementation is enough for the accessibility experts to review it.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
