### PR TITLE
UHF-5923: Added missing translations for Job listing search fallback

### DIFF
--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -34,3 +34,9 @@ msgstr "Hae työpaikkaa"
 
 msgid "See all related jobs"
 msgstr "Katso kaikki suositellut työpaikat"
+
+msgctxt "Job listing search count"
+msgid "open job listing"
+msgid_plural "open job listings"
+msgstr[0] "avoin työpaikka"
+msgstr[1] "avointa työpaikkaa"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -34,3 +34,9 @@ msgstr "Sök jobbet"
 
 msgid "See all related jobs"
 msgstr "Se alla rekommenderade jobb"
+
+msgctxt "Job listing search count"
+msgid "open job listing"
+msgid_plural "open job listings"
+msgstr[0] "öppet jobbannons"
+msgstr[1] "öppna jobbannonser"


### PR DESCRIPTION
Add missing translations for the job listing search fallback view.

1. Setup the Rekry instance with this branch and create a landing page in Finnish with the new paragraph "Job application search".
2. `make shell` and inside the shell run `drush locale:check; drush locale:update; drush cr`
3. Go to the landing page that has the job application search and make sure that the open job applications text is now translated in Finnish version.