### PR TITLE
UHF-7444: Added condition around pay-metadata field printing

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3997,16 +3997,16 @@
         },
         {
             "name": "drupal/hdbt",
-            "version": "4.3.0",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-hdbt.git",
-                "reference": "c9dc8ce1b7629521a08ac7de7ff3cc7a1f352573"
+                "reference": "11106cb459bb9dd57fb7536eca7c44ce48df1c40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/c9dc8ce1b7629521a08ac7de7ff3cc7a1f352573",
-                "reference": "c9dc8ce1b7629521a08ac7de7ff3cc7a1f352573",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-hdbt/zipball/11106cb459bb9dd57fb7536eca7c44ce48df1c40",
+                "reference": "11106cb459bb9dd57fb7536eca7c44ce48df1c40",
                 "shasum": ""
             },
             "require": {
@@ -4021,10 +4021,10 @@
                 "Drupal"
             ],
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/4.3.0",
+                "source": "https://github.com/City-of-Helsinki/drupal-hdbt/tree/4.3.1",
                 "issues": "https://github.com/City-of-Helsinki/drupal-hdbt/issues"
             },
-            "time": "2022-11-16T10:05:53+00:00"
+            "time": "2022-11-22T11:20:25+00:00"
         },
         {
             "name": "drupal/hdbt_admin",
@@ -16816,5 +16816,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -134,7 +134,7 @@
 
         {% set metadata = [
           { label: 'Application period ends'|t, icon: 'clock', content: content.field_publication_ends },
-          { label: 'Pay'|t, icon: 'glyph-euro', content: content.field_salary },
+          content.field_salary|render ? { label: 'Pay'|t, icon: 'glyph-euro', content: content.field_salary },
           { label: 'Employment contract'|t, icon: 'calendar', content: content.field_job_duration },
           { label: 'Address'|t, icon: 'location', content: [content.field_address, content.field_postal_code, content.field_postal_area] },
           { label: 'Published'|t, icon: 'calendar-clock', content: publication_starts },


### PR DESCRIPTION
# [UHF-7444](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7444)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Pay-information is hidden if there is no value given to it.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7444_hide_salary_information_when_not_provided`
  * `composer require drupal/hdbt:dev-UHF-7444_hide_salary_information_when_not_provided`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to edit any job listing content and remove the Salary field content and save the node.
* [ ] There shouldn't have anymore "Pay"-information with "-" as value written on the node metadata box.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/484
