### PR TITLE
UHF-7570: Job listing URL pattern

### DIFF
--- a/conf/cmi/pathauto.pattern.job_listing_content_pattern_finnish.yml
+++ b/conf/cmi/pathauto.pattern.job_listing_content_pattern_finnish.yml
@@ -8,20 +8,20 @@ dependencies:
 id: job_listing_content_pattern_finnish
 label: 'Job listing content pattern - Finnish'
 type: 'canonical_entities:node'
-pattern: '[node:menu-link:parents:join-path]/avoimet-tyopaikat/[node:field_recruitment_id]'
+pattern: '[node:menu-link:parents:join-path]/avoimet-tyopaikat/[node:title]/[node:field_recruitment_id]'
 selection_criteria:
-  cde1330d-3305-41ef-90cb-6b53cbb71fa4:
+  92468ed8-5e56-40f6-b910-40734db09619:
     id: 'entity_bundle:node'
     negate: false
-    uuid: cde1330d-3305-41ef-90cb-6b53cbb71fa4
+    uuid: 92468ed8-5e56-40f6-b910-40734db09619
     context_mapping:
       node: node
     bundles:
       job_listing: job_listing
-  40db6691-1cbc-488e-aa4d-9f52a4575e15:
+  45670eef-2fca-4e6a-8080-1ca44d5c4e9f:
     id: language
     negate: false
-    uuid: 40db6691-1cbc-488e-aa4d-9f52a4575e15
+    uuid: 45670eef-2fca-4e6a-8080-1ca44d5c4e9f
     context_mapping:
       language: 'node:langcode:language'
     langcodes:


### PR DESCRIPTION
# [UHF-7570](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7570)
Improves job listing search engine optimization.

## What was done
- Added node (job listing) title to the URL pattern

## How to install
1. Set up REKRY instance
2. Checkout this branch: `git checkout UHF-7570_job_listing_url_pattern`
3. Import config: `make drush-cim`
4. In `/admin/config/search/path/update_bulk`, select `Content` and `Update the URL alias for paths having an old URL alias` and click `Update`

## How to test
Open any job listing node and make sure that the node title is included in the URL pattern.

## Designers review
* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)
