### PR TITLE
UHF-7859: Added permission to edit Organization terms to administrators and editors

### DIFF
--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -15,6 +15,7 @@ dependencies:
     - node.type.landing_page
     - node.type.page
     - taxonomy.vocabulary.keywords
+    - taxonomy.vocabulary.organization
   module:
     - block
     - config_translation
@@ -145,10 +146,11 @@ permissions:
   - 'edit paragraph library item'
   - 'edit remote entities'
   - 'edit terms in keywords'
+  - 'edit terms in organization'
   - 'restful get helfi_debug_data'
   - 'revert all revisions'
-  - 'revert job_listing revisions'
   - 'revert announcement revisions'
+  - 'revert job_listing revisions'
   - 'revert landing_page revisions'
   - 'revert page revisions'
   - 'schedule publishing of nodes'
@@ -190,8 +192,3 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
-  - 'create hel_map media'
-  - 'delete any hel_map media'
-  - 'delete own hel_map media'
-  - 'edit any hel_map media'
-  - 'edit own hel_map media'

--- a/conf/cmi/user.role.editor.yml
+++ b/conf/cmi/user.role.editor.yml
@@ -12,11 +12,12 @@ dependencies:
     - media.type.job_listing_image
     - media.type.remote_video
     - media.type.soundcloud
-    - node.type.job_listing
     - node.type.announcement
+    - node.type.job_listing
     - node.type.landing_page
     - node.type.page
     - taxonomy.vocabulary.keywords
+    - taxonomy.vocabulary.organization
   module:
     - content_translation
     - editoria11y
@@ -126,8 +127,9 @@ permissions:
   - 'edit paragraph library item'
   - 'edit remote entities'
   - 'edit terms in keywords'
-  - 'revert job_listing revisions'
+  - 'edit terms in organization'
   - 'revert announcement revisions'
+  - 'revert job_listing revisions'
   - 'revert landing_page revisions'
   - 'revert page revisions'
   - 'schedule publishing of nodes'
@@ -165,8 +167,3 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
-  - 'create hel_map media'
-  - 'delete any hel_map media'
-  - 'delete own hel_map media'
-  - 'edit any hel_map media'
-  - 'edit own hel_map media'


### PR DESCRIPTION
# [UHF-7859](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7859)

None of the user roles had a permission to edit the terms in the Organization vocabulary.

## What was done

* Added `edit terms in organization` permission to administrator and editor roles.
* Removed some duplicate lines in config.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git fetch; git checkout UHF-7859_organization-taxonomy-permissions`
* Run `make drush-cim`

## How to test

* [ ] If there are no terms in the organization vocabulary yet, add one as the admin user.
* [ ] Check that a user with the administrator role has access to edit an organization term and especially the image in it.
* [ ] Check that a user with the editor role has access to edit an organization term and especially the image in it.

## Designers review

* [ ] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-7859]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ