### PR TITLE
UHF-7932: Add missing announcements block configuration

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_announcements.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_announcements.yml
@@ -1,0 +1,20 @@
+uuid: 6a407c7e-1837-4420-abb4-db20529786b3
+langcode: en
+status: true
+dependencies:
+  module:
+    - helfi_announcements
+  theme:
+    - hdbt_subtheme
+id: hdbt_subtheme_announcements
+theme: hdbt_subtheme
+region: before_content
+weight: -11
+provider: null
+plugin: announcements
+settings:
+  id: announcements
+  label: Announcements
+  label_display: '0'
+  provider: helfi_announcements
+visibility: {  }

--- a/conf/cmi/block.block.hdbt_subtheme_heroblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_heroblock.yml
@@ -12,7 +12,7 @@ _core:
 id: hdbt_subtheme_heroblock
 theme: hdbt_subtheme
 region: before_content
-weight: -11
+weight: -10
 provider: null
 plugin: hero_block
 settings:


### PR DESCRIPTION
# [UHF-7932](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7932)
Announcements block wasn't visible in Rekry instance.

## What was done
* Added missing announcements block configuration.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7932_announcements-block`
* Run `make drush-cim`

## How to test

* [ ] Add an announcement node.
* [ ] Go to some page in rekry site and check the announcement is visible.

## Designers review

* [x] This PR does not need designers review

[UHF-7932]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ