### PR TITLE
UHF-7964: updated breadcrumb configurations to match all the other sites

### DIFF
--- a/conf/cmi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/easy_breadcrumb.settings.yml
@@ -1,13 +1,13 @@
 _core:
   default_config_hash: azWBxQFowXKyqUvvROIrMBXpwGaxz4JxhL6xz420P3Q
-applies_admin_routes: true
+applies_admin_routes: false
 include_invalid_paths: false
 excluded_paths: ''
 replaced_titles: ''
 custom_paths: ''
-include_home_segment: false
-alternative_title_field: field_breadcrumb_title
-home_segment_title: Home
+include_home_segment: true
+alternative_title_field: ''
+home_segment_title: 'Open jobs'
 home_segment_keep: false
 include_title_segment: true
 title_from_page_when_available: true
@@ -17,18 +17,19 @@ use_page_title_as_menu_title_fallback: false
 remove_repeated_segments: true
 language_path_prefix_as_segment: false
 absolute_paths: false
-hide_single_home_item: false
+hide_single_home_item: true
 term_hierarchy: false
 use_site_title: false
 add_structured_data_json_ld: false
-capitalizator_mode: ucwords
+capitalizator_mode: none
 capitalizator_ignored_words: {  }
 capitalizator_forced_words: {  }
 capitalizator_forced_words_case_sensitivity: true
 capitalizator_forced_words_first_letter: false
-follow_redirects: true
+follow_redirects: false
 limit_segment_display: false
 segment_display_limit: ''
 truncator_mode: false
 truncator_length: 100
 truncator_dots: true
+

--- a/conf/cmi/language/fi/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/fi/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Etusivu
+home_segment_title: Avoimet työpaikat

--- a/conf/cmi/language/sv/easy_breadcrumb.settings.yml
+++ b/conf/cmi/language/sv/easy_breadcrumb.settings.yml
@@ -1,1 +1,1 @@
-home_segment_title: Hem
+home_segment_title: Lediga jobb


### PR DESCRIPTION
# [UHF-7964](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7964)

Updated breadcrumb configurations

## What was done

- On subpages, breadcrumb used to be wrong: `etusivu > alasivu`
- Now it's fixed to: `etusivu > avoimet työpaikat > alasivu`

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7964_breadcrumb_configuration`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Click any link on menu
- Check breadcrumb.
  - Breadcrumb should be in this format:  `etusivu > avoimet työpaikat > alasivu`
  - Check with all languages. Second link should always be either `avoimet työpaikat` or `open jobs` or `lediga jobb`   


[UHF-7964]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ