### PR TITLE
UHF-7968: Link fix for the button at the end of a job listing page

### DIFF
--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -23,15 +23,9 @@ function hdbt_subtheme_preprocess_block(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_block__views_block__of_interest(&$variables) {
-  /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolver $resolver */
-  $resolver = \Drupal::service('helfi_api_base.environment_resolver');
-  /** @var \Drupal\helfi_api_base\Environment\Environment $environment */
-  $environment = $resolver->getActiveEnvironment();
-  $base_url = $environment->getBaseUrl();
-
   // @todo Get the node id somehow else than hardcoded here (UHF-7999).
-  $alias = Url::fromRoute('entity.node.canonical', ['node' => 2971], ['absolute' => FALSE]);
-  $variables['related_jobs_link'] = $base_url . $alias->toString();
+  $alias = Url::fromRoute('entity.node.canonical', ['node' => 2971], ['absolute' => TRUE]);
+  $variables['related_jobs_link'] = $alias;
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -8,6 +8,7 @@
 use Drupal\Core\Render\Element;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
+use Drupal\Core\Url;
 
 /**
  * Implements hook_preprocess_HOOK().
@@ -22,8 +23,15 @@ function hdbt_subtheme_preprocess_block(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_block__views_block__of_interest(&$variables) {
-  // @todo change to correct url
-  $variables['related_jobs_link'] = 'https://helfi-rekry.docker.so/';
+  /** @var \Drupal\helfi_api_base\Environment\EnvironmentResolver $resolver */
+  $resolver = \Drupal::service('helfi_api_base.environment_resolver');
+  /** @var \Drupal\helfi_api_base\Environment\Environment $environment */
+  $environment = $resolver->getActiveEnvironment();
+  $base_url = $environment->getBaseUrl();
+
+  // @todo Get the node id somehow else than hardcoded here (UHF-7999).
+  $alias = Url::fromRoute('entity.node.canonical', ['node' => 2971], ['absolute' => FALSE]);
+  $variables['related_jobs_link'] = $base_url . $alias->toString();
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--of-interest.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--of-interest.html.twig
@@ -41,7 +41,7 @@
     {% block content %}
       {{ content }}
       {% set link_title %}
-        <span class="hds-button__label">{{ 'See all related jobs'|t }}</span>
+        <span class="hds-button__label">{{ 'Find open jobs'|t({}, {'context': 'Related jobs button'}) }}</span> 
       {% endset %}
       {% set link_attributes = {
         'class': [

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--of-interest.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--of-interest.html.twig
@@ -49,8 +49,7 @@
           'hds-button--primary',
         ],
       } %}
-      {# @todo: enable once link is fixed #}
-      {# {{ link(link_title, related_jobs_link, link_attributes) }} #}
+      {{ link(link_title, related_jobs_link, link_attributes) }}
     {% endblock %}
    </div>
 </div>

--- a/public/themes/custom/hdbt_subtheme/translations/fi.po
+++ b/public/themes/custom/hdbt_subtheme/translations/fi.po
@@ -40,3 +40,7 @@ msgid "open job listing"
 msgid_plural "open job listings"
 msgstr[0] "työpaikkailmoitus"
 msgstr[1] "työpaikkailmoitusta"
+
+msgctxt "Related jobs button"
+msgid "Find open jobs"
+msgstr "Etsi avoimia paikkoja"

--- a/public/themes/custom/hdbt_subtheme/translations/sv.po
+++ b/public/themes/custom/hdbt_subtheme/translations/sv.po
@@ -40,3 +40,7 @@ msgid "open job listing"
 msgid_plural "open job listings"
 msgstr[0] "öppet jobbannons"
 msgstr[1] "öppna jobbannonser"
+
+msgctxt "Related jobs button"
+msgid "Find open jobs"
+msgstr "Sök lediga jobb"


### PR DESCRIPTION
# [UHF-7968](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7968)
The button at the end of a job listing page had a local environment link.

## What was done
* Changed the URL to the job listing page's URL. This was supposed to be a hotfix so it is hardcoded. Created a ticket UHF-7999 for the todo that is left.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7968_find-open-jobs-button`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to any job listings page and find the "of interest" block at the end of the page. Check that the button takes to node 2971. If the page exists on local, the href should be an alias instead of node/id.
* [ ] Check that the button has correct copy and translations (correct ones in the [ticket](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7968))

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-7968]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ