### PR TITLE
UHF-8003: Enabled react and share block

### DIFF
--- a/conf/cmi/block.block.hdbt_subtheme_eucookiecomplianceblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_eucookiecomplianceblock.yml
@@ -12,7 +12,7 @@ _core:
 id: hdbt_subtheme_eucookiecomplianceblock
 theme: hdbt_subtheme
 region: after_content
-weight: -8
+weight: -14
 provider: null
 plugin: eu_cookie_compliance_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_lowercontentblock.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_lowercontentblock.yml
@@ -11,7 +11,7 @@ _core:
 id: hdbt_subtheme_lowercontentblock
 theme: hdbt_subtheme
 region: after_content
-weight: -9
+weight: -15
 provider: null
 plugin: lower_content_block
 settings:

--- a/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
+++ b/conf/cmi/block.block.hdbt_subtheme_reactandshare.yml
@@ -1,6 +1,6 @@
 uuid: 72f1ed73-0fa9-4f47-a032-894ac76c4ab4
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - helfi_platform_config
@@ -11,7 +11,7 @@ _core:
 id: hdbt_subtheme_reactandshare
 theme: hdbt_subtheme
 region: after_content
-weight: -7
+weight: -12
 provider: null
 plugin: react_and_share
 settings:

--- a/conf/cmi/block.block.views_block__of_interest.yml
+++ b/conf/cmi/block.block.views_block__of_interest.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__of_interest
 theme: hdbt_subtheme
 region: after_content
-weight: 0
+weight: -13
 provider: null
 plugin: 'views_block:of_interest-block_1'
 settings:


### PR DESCRIPTION
# [UHF-8003](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8003)
React and share block is wanted on the Rekry site.

## What was done
* Enabled the react and share block on the Rekry site.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8003_Rekry-react-and-share`
* Run `make drush-cim`
* Add the API keys to `local.settings.php` (replace the keys with real ones).
  * `putenv('REACT_AND_SHARE_APIKEY_FI=abcdefghi123456789');`
  * `putenv('REACT_AND_SHARE_APIKEY_SV=abcdefghi123456789');`
  * `putenv('REACT_AND_SHARE_APIKEY_EN=abcdefghi123456789');`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that, after accepting cookies, the react and share block is visible in bottom of the pages.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8003]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ