### PR TITLE
UHF-7999: Move hardcoded search page node id to settings form.

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -4,3 +4,4 @@ ignored_config_entities:
   - 'eu_cookie_compliance.cookie_category*'
   - hdbt_admin_tools.site_settings
   - 'system.site:page.front'
+  - 'helfi_rekry_content.job_listings:search_page'

--- a/conf/cmi/helfi_rekry_content.job_listings.yml
+++ b/conf/cmi/helfi_rekry_content.job_listings.yml
@@ -1,3 +1,4 @@
 redirect_403: /job-listing-removed
 city_description_title: 'City of Helsinki'
 city_description_text: 'The City of Helsinki is actively promoting equality and non-discrimination and values the diversity of its personnel. We encourage applications from people of all ages and genders, as well as from people who belong to linguistic, cultural or other minorities.'
+search_page: '2971'

--- a/public/modules/custom/helfi_rekry_content/config/schema/helfi_rekry_content.schema.yml
+++ b/public/modules/custom/helfi_rekry_content/config/schema/helfi_rekry_content.schema.yml
@@ -3,6 +3,9 @@ helfi_rekry_content.job_listings:
   type: config_object
   label: 'Job listings'
   mapping:
+    search_page:
+      type: string
+      label: 'Search page node ID'
     redirect_403:
       type: path
       label: 'Redirect 403 path'

--- a/public/modules/custom/helfi_rekry_content/src/Form/SettingsForm.php
+++ b/public/modules/custom/helfi_rekry_content/src/Form/SettingsForm.php
@@ -73,11 +73,7 @@ class SettingsForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $siteConfig = $this->config('helfi_rekry_content.job_listings');
-
-    $search_page_node = NULL;
-    if ($siteConfig->get('search_page')) {
-      $search_page_node = Node::load($siteConfig->get('search_page'));
-    }
+    $searchPage = Node::load($siteConfig->get('search_page'));
     $form['job_listings']['search_page'] = [
       '#type' => 'entity_autocomplete',
       '#target_type' => 'node',
@@ -85,7 +81,7 @@ class SettingsForm extends ConfigFormBase {
         'target_bundles' => ['landing_page', 'page'],
       ],
       '#title' => $this->t('Job search page'),
-      '#default_value' => $search_page_node,
+      '#default_value' => $searchPage,
       '#description' => $this->t('Displayed after the related jobs block, for example.'),
     ];
 

--- a/public/modules/custom/helfi_rekry_content/src/Form/SettingsForm.php
+++ b/public/modules/custom/helfi_rekry_content/src/Form/SettingsForm.php
@@ -8,6 +8,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Path\PathValidatorInterface;
+use Drupal\node\Entity\Node;
 use Drupal\path_alias\AliasManagerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -73,6 +74,21 @@ class SettingsForm extends ConfigFormBase {
   public function buildForm(array $form, FormStateInterface $form_state): array {
     $siteConfig = $this->config('helfi_rekry_content.job_listings');
 
+    $search_page_node = NULL;
+    if ($siteConfig->get('search_page')) {
+      $search_page_node = Node::load($siteConfig->get('search_page'));
+    }
+    $form['job_listings']['search_page'] = [
+      '#type' => 'entity_autocomplete',
+      '#target_type' => 'node',
+      '#selection_settings' => [
+        'target_bundles' => ['landing_page', 'page'],
+      ],
+      '#title' => $this->t('Job search page'),
+      '#default_value' => $search_page_node,
+      '#description' => $this->t('Displayed after the related jobs block, for example.'),
+    ];
+
     $form['job_listings']['redirect_403'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Unpublished job listing redirect page for anonymous users'),
@@ -118,6 +134,7 @@ class SettingsForm extends ConfigFormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->config('helfi_rekry_content.job_listings')
+      ->set('search_page', $form_state->getValue('search_page'))
       ->set('redirect_403', $form_state->getValue('redirect_403'))
       ->set('city_description_title', $form_state->getValue('city_description_title'))
       ->set('city_description_text', $form_state->getValue('city_description_text'))

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -23,9 +23,15 @@ function hdbt_subtheme_preprocess_block(&$variables) {
  * Implements hook_preprocess_HOOK().
  */
 function hdbt_subtheme_preprocess_block__views_block__of_interest(&$variables) {
-  // @todo Get the node id somehow else than hardcoded here (UHF-7999).
-  $alias = Url::fromRoute('entity.node.canonical', ['node' => 2971], ['absolute' => TRUE]);
-  $variables['related_jobs_link'] = $alias;
+  // Get the search page nid from config.
+  $config = \Drupal::config('helfi_rekry_content.job_listings');
+  $search_page_nid = $config->get('search_page');
+  if ($search_page_nid) {
+    $alias = Url::fromRoute('entity.node.canonical', ['node' => $search_page_nid], ['absolute' => TRUE]);
+  }
+  if ($alias) {
+    $variables['related_jobs_link'] = $alias;
+  }
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--of-interest.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/block--views-block--of-interest.html.twig
@@ -41,7 +41,7 @@
     {% block content %}
       {{ content }}
       {% set link_title %}
-        <span class="hds-button__label">{{ 'Find open jobs'|t({}, {'context': 'Related jobs button'}) }}</span> 
+        <span class="hds-button__label">{{ 'Find open jobs'|t({}, {'context': 'Related jobs button'}) }}</span>
       {% endset %}
       {% set link_attributes = {
         'class': [
@@ -49,7 +49,9 @@
           'hds-button--primary',
         ],
       } %}
-      {{ link(link_title, related_jobs_link, link_attributes) }}
+      {% if related_jobs_link %}
+        {{ link(link_title, related_jobs_link, link_attributes) }}
+      {% endif %}
     {% endblock %}
    </div>
 </div>


### PR DESCRIPTION
# [UHF-7999](https://helsinkisolutionoffice.atlassian.net/browse/UHF-7999)

## What was done
This PR moves a hardcoded value to Rekry's settings form.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-7999-add-search-page-to-settings`
  * `make fresh`
* Run `make drush-cr`

## How to test
* [x] Go to any published job listing https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/admin/content?title=&type=job_listing&status=1&langcode=fi and note that the "Etsi avoimia työpaikkoja" at the bottom of the "Sinua voisi kiinnostaa..." list is missing
* [x] Go to Rekry's setting form: https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/admin/tools/rekry-content and add the "Etsi avoimia työpaikkoja" node in the "Job search page" setting (should be node ID 2971 if you pulled content from test)
* [x] Run `make drush-cr`, then reload the job listing page. The button should now be visible and the link should lead to the node you added in the settings
* [x] Check that the button translations work on other language versions
* [x] Check that code follows our standards

## Designers review

* [x] This PR does not need designers review

[UHF-7999]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-7999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ