### PR TITLE
UHF-8102: job search metatags pt.2

### DIFF
--- a/conf/cmi/core.entity_form_display.taxonomy_term.task_area.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.task_area.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.task_area.field_external_id
+    - field.field.taxonomy_term.task_area.field_meta_description
     - field.field.taxonomy_term.task_area.field_metadata
     - taxonomy.vocabulary.task_area
   module:
@@ -15,16 +16,24 @@ bundle: task_area
 mode: default
 content:
   description:
-    type: text_textfield
+    type: text_textarea
     weight: 0
     region: content
     settings:
-      size: 60
+      rows: 5
       placeholder: ''
     third_party_settings: {  }
   field_external_id:
     type: string_textfield
     weight: 101
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_meta_description:
+    type: string_textfield
+    weight: 103
     region: content
     settings:
       size: 60

--- a/conf/cmi/core.entity_view_display.taxonomy_term.task_area.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.task_area.default.yml
@@ -4,6 +4,7 @@ status: true
 dependencies:
   config:
     - field.field.taxonomy_term.task_area.field_external_id
+    - field.field.taxonomy_term.task_area.field_meta_description
     - field.field.taxonomy_term.task_area.field_metadata
     - taxonomy.vocabulary.task_area
   module:
@@ -27,6 +28,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_meta_description:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   field_metadata:
     type: string

--- a/conf/cmi/field.field.taxonomy_term.task_area.field_meta_description.yml
+++ b/conf/cmi/field.field.taxonomy_term.task_area.field_meta_description.yml
@@ -1,9 +1,9 @@
-uuid: 9dbe2125-8014-4501-9fd1-895c563bbe98
+uuid: 284ae7b5-54c6-492f-b028-25310d38aa58
 langcode: en
 status: true
 dependencies:
   config:
-    - field.storage.taxonomy_term.field_metadata
+    - field.storage.taxonomy_term.field_meta_description
     - taxonomy.vocabulary.task_area
   module:
     - disable_field
@@ -11,11 +11,11 @@ third_party_settings:
   disable_field:
     add_disable: none
     edit_disable: none
-id: taxonomy_term.task_area.field_metadata
-field_name: field_metadata
+id: taxonomy_term.task_area.field_meta_description
+field_name: field_meta_description
 entity_type: taxonomy_term
 bundle: task_area
-label: 'Meta title'
+label: 'Meta description'
 description: ''
 required: false
 translatable: true

--- a/conf/cmi/field.storage.taxonomy_term.field_meta_description.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_meta_description.yml
@@ -1,0 +1,21 @@
+uuid: 9626e55e-ee57-4423-8a64-6107c9959c8e
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_meta_description
+field_name: field_meta_description
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/simple_sitemap.custom_links.default.yml
+++ b/conf/cmi/simple_sitemap.custom_links.default.yml
@@ -4,93 +4,93 @@ links:
     priority: '1.0'
     changefreq: daily
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=32&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=32&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=33&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=33&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=34&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=34&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=35&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=35&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=36&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=36&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=37&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=37&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=240&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=240&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=241&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=241&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=242&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=242&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=253&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=253&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=255&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=255&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=256&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=256&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=257&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=257&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=258&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=258&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=982&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=982&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=984&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=984&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=985&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=985&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=986&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=986&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=987&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=987&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=981&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=981&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=1097&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=1097&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=1098&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=1098&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=1099&page=1'
+    path: '/etsi-avoimia-tyopaikkoja?task_areas=1099&page=1'
     priority: '1.0'

--- a/conf/cmi/user.role.admin.yml
+++ b/conf/cmi/user.role.admin.yml
@@ -18,6 +18,7 @@ dependencies:
     - rest.resource.helfi_debug_data
     - taxonomy.vocabulary.keywords
     - taxonomy.vocabulary.organization
+    - taxonomy.vocabulary.task_area
   module:
     - block
     - config_translation
@@ -191,3 +192,5 @@ permissions:
   - 'view scheduled content'
   - 'view the administration theme'
   - 'view unpublished paragraphs'
+  - 'translate task_area taxonomy_term'
+  - 'edit terms in task_area'

--- a/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module
+++ b/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module
@@ -40,6 +40,27 @@ function helfi_rekry_job_search_page_attachments_alter(array &$attachments) {
 
   $currentUri = \Drupal::request()->getUri();
   $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
+    'vid' => 'task_area',
+    'field_external_id' => $queryParams['task_areas'],
+  ]);
+
+  $term = reset($term);
+  if ($term->hasTranslation($langcode)) {
+    $term = $term->getTranslation($langcode);
+  }
+
+  if ($term->hasField('field_meta_description') && !$term->get('field_meta_description')->isEmpty()) {
+    $description = [
+      '#tag' => 'meta',
+      '#attributes' => [
+        'name' => 'description',
+        'content' => $term->get('field_meta_description')->getString(),
+      ],
+    ];
+
+    $attachments['#attached']['html_head'][] = [$description, 'description'];
+  }
 
   foreach ($attachments['#attached']['html_head'] as $key => $head) {
     switch ($head[1]) {
@@ -54,16 +75,6 @@ function helfi_rekry_job_search_page_attachments_alter(array &$attachments) {
 
       case 'og_title':
       case 'twitter_cards_title':
-        $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
-          'vid' => 'task_area',
-          'field_external_id' => $queryParams['task_areas'],
-        ]);
-
-        $term = reset($term);
-        if ($term->hasTranslation($langcode)) {
-          $term = $term->getTranslation($langcode);
-        }
-
         if ($term->hasField('field_metadata') && !$term->get('field_metadata')->isEmpty()) {
           $attachments['#attached']['html_head'][$key][0]['#attributes']['content'] = $term->get('field_metadata')->getString();
         }

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -221,4 +221,47 @@ function hdbt_subtheme_preprocess_html(&$variables) {
   if ($environment === 'prod') {
     $variables['#attached']['library'][] = 'hdbt_subtheme/siteimprove-analytics';
   }
+
+  _update_job_search_task_area_page_title_tag($variables);
+}
+
+/**
+ * Set title tag for job search task area pages.
+ *
+ * @param array $variables
+ *   Variables array.
+ */
+function _update_job_search_task_area_page_title_tag(&$variables) {
+  $query_params = \Drupal::request()->query->all();
+
+  if (!array_key_exists('task_areas', $query_params)) {
+    return;
+  }
+
+  // Only task_area and page paramaters allowed.
+  foreach ($query_params as $query_param => $query_param_value) {
+    if ($query_param !== 'task_areas' && $query_param !== 'page') {
+      return;
+    }
+  }
+
+  // Only one task_area category allowed.
+  if (substr_count(\Drupal::request()->getRequestUri(), 'task_areas') > 1) {
+    return;
+  }
+
+  $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
+    'vid' => 'task_area',
+    'field_external_id' => $query_params['task_areas'],
+  ]);
+
+  $term = reset($term);
+  if ($term->hasTranslation($langcode)) {
+    $term = $term->getTranslation($langcode);
+  }
+
+  if ($term->hasField('field_metadata') && !$term->get('field_metadata')->isEmpty()) {
+    $variables['head_title']['title'] = html_entity_decode($term->get('field_metadata')->getString(), ENT_QUOTES);
+  }
 }


### PR DESCRIPTION
# [UHF-8102](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8102)
<!-- What problem does this solve? -->

Improvements for adding custom metadata to job search task area pages

## What was done
<!-- Describe what was done -->

* Add custom meta title and description creation for job search task area pages
* Add meta description field for task area term
* Add permissions to edit task area terms for admin
* Update task area custom sitemap URLs

## How to install

* Make sure REKRY instance is up and running on correct branch.
* `git checkout UHF-8102-job-search-metatags`

**Setup for ES proxy**
* Run `make ps` to get the correct proxy port: `drupal-helfi-rekry-elastic`. Should be 9200 but might change if you have multiple ES proxies running.
* Edit the `.env` file:
  * Change the port in `ELASTIC_PROXY_URL`

**Make sure your instance is up-to-date:**
* `make fresh`
* If you get an `ERROR 1273 (HY000) at line 14784: Unknown collation: 'utf8mb4_0900_ai_ci'` error with the database import, run `make shell` and then:
  * `sed -i 's/utf8mb4_0900_ai_ci/utf8mb4_swedish_ci/g' dump.sql; drush sql-query --file=/app/dump.sql && drush helfi:oc:sanitize-database && drush cim -y;drush updb -y;drush cr;drush uli` 
* Run these in the container to update Elastic indexes:
```
drush sapi-rt
drush sapi-i
``` 
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to page: https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja
* [x] Check that search works with task area filter selection and otherwise too
* [x] Make search with ONLY ONE task area e.g. https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja?task_areas=37&page=1
* [x] Reload the page with the search query params
* [x] Open inspector and check page metadata from head element. Canonical link, `og:url `and `twitter:url` should have the URL with search parameter as value. title tag, `og:title` and` twitter:title` should have metadata from taxonomy term field_metadata if it's set for the term. Description tag should have metadata from taxonomy term is it's set for the term, Otherwise title and description should stay as page default.
* [x] Go to update some term metadata for testing: https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/admin/structure/taxonomy/manage/task_area/overview
* Test also with user that has admin (pääkäyttäjä) role that role has permissions to update task area terms.
* [x] Add also translated metadata for the term
* [x] Test also that translated metadata work https://helfi-rekry.docker.so/sv/lediga-jobb/sok-lediga-jobb?task_areas=37&page=1
* [x] Make search with multiple task areas and with other filters too and reload the page with the query params. Metadata should update only when there's one task area selected and no other filters. Ignore page param, it doesn't make difference.
* [ ] Check that sitemap has all URLs (also translated) with different task areas: https://helfi-rekry.docker.so/sitemap.xml
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8102]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ