### PR TITLE
prevent error when term is false

### DIFF
--- a/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module
+++ b/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module
@@ -46,11 +46,11 @@ function helfi_rekry_job_search_page_attachments_alter(array &$attachments) {
   ]);
 
   $term = reset($term);
-  if ($term->hasTranslation($langcode)) {
+  if ($term && $term->hasTranslation($langcode)) {
     $term = $term->getTranslation($langcode);
   }
 
-  if ($term->hasField('field_meta_description') && !$term->get('field_meta_description')->isEmpty()) {
+  if ($term && $term->hasField('field_meta_description') && !$term->get('field_meta_description')->isEmpty()) {
     $description = [
       '#tag' => 'meta',
       '#attributes' => [


### PR DESCRIPTION
Fixed this error:
Error: Call to a member function hasTranslation() on bool in helfi_rekry_job_search_page_attachments_alter() (line 49 of /var/www/html/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module)