### PR TITLE
UHF-8290: missing language type parameter in subtheme and job search module

### DIFF
--- a/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module
+++ b/public/modules/custom/helfi_rekry_job_search/helfi_rekry_job_search.module
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\helfi_platform_config\DTO\ParagraphTypeCollection;
 
 /**
@@ -41,7 +42,9 @@ function helfi_rekry_job_search_page_attachments_alter(array &$attachments) {
   }
 
   $currentUri = \Drupal::request()->getUri();
-  $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $langcode = \Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
   $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
     'vid' => 'task_area',
     'field_external_id' => $queryParams['task_areas'],

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -7,6 +7,7 @@
 
 declare(strict_types = 1);
 
+use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Render\Element;
 use Drupal\node\Entity\Node;
 use Drupal\node\NodeInterface;
@@ -178,7 +179,9 @@ function hdbt_subtheme_preprocess_paragraph__job_search(array &$variables) {
   if ($paragraph_type == 'job_search') {
     if ($search_result_page_nid = $paragraph->get('field_job_search_result_page')->getString()) {
       $entity = Node::load($search_result_page_nid);
-      $language = \Drupal::languageManager()->getCurrentLanguage()->getId();
+      $language = \Drupal::languageManager()
+        ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+        ->getId();
 
       if ($entity->hasTranslation($language)) {
         $entity = $entity->getTranslation($language);
@@ -236,7 +239,9 @@ function _update_job_search_task_area_page_title_tag(array &$variables) {
     return;
   }
 
-  $langcode = \Drupal::languageManager()->getCurrentLanguage()->getId();
+  $langcode = \Drupal::languageManager()
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT)
+    ->getId();
   $term = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
     'vid' => 'task_area',
     'field_external_id' => $query_params['task_areas'],


### PR DESCRIPTION
Missing language type parameter in hdbt subtheme and job search module. Both are related to job search:

_update_job_search_task_area_page_title_tag -funktion and helfi_rekry_job_search_page_attachments_alter
