### PR TITLE
UHF-8459: Removed link from employment type tag on job listing

### DIFF
--- a/conf/cmi/core.entity_view_display.node.job_listing.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.teaser.yml
@@ -44,7 +44,7 @@ content:
     type: entity_reference_label
     label: above
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
     weight: 1
     region: content


### PR DESCRIPTION
# [UHF-8459](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8459)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Removed linking to taxonomy term listing from employment tag on job listing fallback view.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8459_remove_employment_type_link`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Go to https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja and disable javascript and reload the page.
* [x] Inspect that the gray tag doesn't have link anymore that links to taxonomy term listing.
* [x] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)


[UHF-8459]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ