### PR TITLE
UHF-8471 field translatable

### DIFF
--- a/conf/cmi/field.field.node.job_listing.field_address.yml
+++ b/conf/cmi/field.field.node.job_listing.field_address.yml
@@ -20,7 +20,7 @@ bundle: job_listing
 label: Address
 description: 'Address where the job takes place.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.job_listing.field_contacts.yml
+++ b/conf/cmi/field.field.node.job_listing.field_contacts.yml
@@ -24,7 +24,7 @@ bundle: job_listing
 label: Contacts
 description: 'Contact information for the listing.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/public/modules/custom/helfi_rekry_content/config/install/field.field.node.job_listing.field_address.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/field.field.node.job_listing.field_address.yml
@@ -12,7 +12,7 @@ bundle: job_listing
 label: Address
 description: 'Address where the job takes place.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/public/modules/custom/helfi_rekry_content/config/install/field.field.node.job_listing.field_contacts.yml
+++ b/public/modules/custom/helfi_rekry_content/config/install/field.field.node.job_listing.field_contacts.yml
@@ -18,7 +18,7 @@ bundle: job_listing
 label: Contacts
 description: 'Contact information for the listing.'
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }


### PR DESCRIPTION
# [UHF-8471](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8471)

## What was done

Set job listing fields (address and contacts) translatable

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8471_field_translatable`
  * `make fresh`
* Run `make drush-cr`

## How to test

Go to `https://helfi-rekry.docker.so/en/open-jobs/admin/config/regional/content-language`
See that field_address and field_contacts are set as translatable


[UHF-8471]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ