### PR TITLE
UHF-8476 job listing override fields

### DIFF
--- a/conf/cmi/core.entity_form_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.node.job_listing.default.yml
@@ -114,7 +114,7 @@ content:
     third_party_settings: {  }
   field_job_description_override:
     type: text_textarea_with_summary
-    weight: 29
+    weight: 28
     region: content
     settings:
       rows: 9
@@ -161,7 +161,7 @@ content:
     third_party_settings: {  }
   field_organization:
     type: entity_reference_autocomplete
-    weight: 33
+    weight: 34
     region: content
     settings:
       match_operator: CONTAINS
@@ -171,7 +171,7 @@ content:
     third_party_settings: {  }
   field_organization_description:
     type: text_textarea
-    weight: 35
+    weight: 36
     region: content
     settings:
       rows: 5
@@ -179,7 +179,7 @@ content:
     third_party_settings: {  }
   field_organization_description_o:
     type: text_textarea
-    weight: 36
+    weight: 35
     region: content
     settings:
       rows: 5
@@ -195,7 +195,7 @@ content:
     third_party_settings: {  }
   field_organization_override:
     type: entity_reference_autocomplete
-    weight: 34
+    weight: 33
     region: content
     settings:
       match_operator: CONTAINS
@@ -294,7 +294,7 @@ content:
     third_party_settings: {  }
   job_description:
     type: text_textarea_with_summary
-    weight: 28
+    weight: 29
     region: content
     settings:
       rows: 9

--- a/conf/cmi/core.entity_form_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.node.job_listing.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.job_listing.field_employment
     - field.field.node.job_listing.field_employment_type
     - field.field.node.job_listing.field_image
+    - field.field.node.job_listing.field_job_description_override
     - field.field.node.job_listing.field_job_duration
     - field.field.node.job_listing.field_jobs
     - field.field.node.job_listing.field_last_changed_remote
@@ -17,7 +18,9 @@ dependencies:
     - field.field.node.job_listing.field_link_to_presentation
     - field.field.node.job_listing.field_organization
     - field.field.node.job_listing.field_organization_description
+    - field.field.node.job_listing.field_organization_description_o
     - field.field.node.job_listing.field_organization_name
+    - field.field.node.job_listing.field_organization_override
     - field.field.node.job_listing.field_original_language
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
@@ -109,6 +112,16 @@ content:
     settings:
       media_types: {  }
     third_party_settings: {  }
+  field_job_description_override:
+    type: text_textarea_with_summary
+    weight: 42
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
   field_job_duration:
     type: string_textfield
     weight: 21
@@ -164,11 +177,29 @@ content:
       rows: 5
       placeholder: ''
     third_party_settings: {  }
+  field_organization_description_o:
+    type: text_textarea
+    weight: 45
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_organization_name:
     type: string_textfield
     weight: 18
     region: content
     settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_organization_override:
+    type: entity_reference_autocomplete
+    weight: 44
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
       size: 60
       placeholder: ''
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.node.job_listing.default.yml
@@ -37,6 +37,7 @@ dependencies:
     - node.type.job_listing
   module:
     - datetime
+    - field_group
     - hdbt_admin_tools
     - link
     - media_library
@@ -44,6 +45,25 @@ dependencies:
     - publication_date
     - scheduler
     - text
+third_party_settings:
+  field_group:
+    group_override_fields:
+      children:
+        - field_prevent_publishing
+        - field_job_description_override
+        - field_organization_override
+        - field_organization_description_o
+      label: 'Override fields'
+      region: content
+      parent_name: ''
+      weight: 15
+      format_type: fieldset
+      format_settings:
+        classes: ''
+        show_empty_fields: false
+        id: ''
+        description: ''
+        required_fields: false
 id: node.job_listing.default
 targetEntityType: node
 bundle: job_listing
@@ -57,7 +77,7 @@ content:
     third_party_settings: {  }
   field_address:
     type: string_textfield
-    weight: 24
+    weight: 25
     region: content
     settings:
       size: 60
@@ -65,14 +85,14 @@ content:
     third_party_settings: {  }
   field_anonymous:
     type: boolean_checkbox
-    weight: 17
+    weight: 18
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_contacts:
     type: text_textarea
-    weight: 31
+    weight: 32
     region: content
     settings:
       rows: 5
@@ -80,14 +100,14 @@ content:
     third_party_settings: {  }
   field_copied:
     type: boolean_checkbox
-    weight: 44
+    weight: 45
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_employment:
     type: entity_reference_autocomplete
-    weight: 19
+    weight: 20
     region: content
     settings:
       match_operator: CONTAINS
@@ -97,7 +117,7 @@ content:
     third_party_settings: {  }
   field_employment_type:
     type: entity_reference_autocomplete
-    weight: 18
+    weight: 19
     region: content
     settings:
       match_operator: CONTAINS
@@ -107,14 +127,14 @@ content:
     third_party_settings: {  }
   field_image:
     type: media_library_widget
-    weight: 32
+    weight: 33
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_job_description_override:
     type: text_textarea_with_summary
-    weight: 28
+    weight: 17
     region: content
     settings:
       rows: 9
@@ -124,7 +144,7 @@ content:
     third_party_settings: {  }
   field_job_duration:
     type: string_textfield
-    weight: 23
+    weight: 24
     region: content
     settings:
       size: 60
@@ -132,20 +152,20 @@ content:
     third_party_settings: {  }
   field_jobs:
     type: number
-    weight: 16
+    weight: 17
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_last_changed_remote:
     type: datetime_default
-    weight: 40
+    weight: 41
     region: content
     settings: {  }
     third_party_settings: {  }
   field_link_to_application:
     type: link_default
-    weight: 21
+    weight: 22
     region: content
     settings:
       placeholder_url: ''
@@ -153,7 +173,7 @@ content:
     third_party_settings: {  }
   field_link_to_presentation:
     type: link_default
-    weight: 41
+    weight: 42
     region: content
     settings:
       placeholder_url: ''
@@ -161,7 +181,7 @@ content:
     third_party_settings: {  }
   field_organization:
     type: entity_reference_autocomplete
-    weight: 34
+    weight: 35
     region: content
     settings:
       match_operator: CONTAINS
@@ -171,7 +191,7 @@ content:
     third_party_settings: {  }
   field_organization_description:
     type: text_textarea
-    weight: 36
+    weight: 37
     region: content
     settings:
       rows: 5
@@ -179,7 +199,7 @@ content:
     third_party_settings: {  }
   field_organization_description_o:
     type: text_textarea
-    weight: 35
+    weight: 19
     region: content
     settings:
       rows: 5
@@ -187,7 +207,7 @@ content:
     third_party_settings: {  }
   field_organization_name:
     type: string_textfield
-    weight: 20
+    weight: 21
     region: content
     settings:
       size: 60
@@ -195,7 +215,7 @@ content:
     third_party_settings: {  }
   field_organization_override:
     type: entity_reference_autocomplete
-    weight: 33
+    weight: 18
     region: content
     settings:
       match_operator: CONTAINS
@@ -205,46 +225,11 @@ content:
     third_party_settings: {  }
   field_original_language:
     type: options_select
-    weight: 45
+    weight: 46
     region: content
     settings: {  }
     third_party_settings: {  }
   field_postal_area:
-    type: string_textfield
-    weight: 26
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_postal_code:
-    type: string_textfield
-    weight: 25
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_prevent_publishing:
-    type: boolean_checkbox
-    weight: 15
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  field_publication_ends:
-    type: datetime_default
-    weight: 43
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_publication_starts:
-    type: datetime_default
-    weight: 42
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_recruitment_id:
     type: string_textfield
     weight: 27
     region: content
@@ -252,16 +237,51 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_postal_code:
+    type: string_textfield
+    weight: 26
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_prevent_publishing:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_publication_ends:
+    type: datetime_default
+    weight: 44
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_publication_starts:
+    type: datetime_default
+    weight: 43
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_recruitment_id:
+    type: string_textfield
+    weight: 28
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_recruitment_type:
     type: number
-    weight: 38
+    weight: 39
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_salary:
     type: string_textfield
-    weight: 22
+    weight: 23
     region: content
     settings:
       size: 60
@@ -269,7 +289,7 @@ content:
     third_party_settings: {  }
   field_salary_class:
     type: string_textfield
-    weight: 30
+    weight: 31
     region: content
     settings:
       size: 60
@@ -277,7 +297,7 @@ content:
     third_party_settings: {  }
   field_task_area:
     type: entity_reference_autocomplete
-    weight: 39
+    weight: 40
     region: content
     settings:
       match_operator: CONTAINS
@@ -287,14 +307,14 @@ content:
     third_party_settings: {  }
   field_video:
     type: media_library_widget
-    weight: 37
+    weight: 38
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   job_description:
     type: text_textarea_with_summary
-    weight: 29
+    weight: 30
     region: content
     settings:
       rows: 9

--- a/conf/cmi/core.entity_form_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_form_display.node.job_listing.default.yml
@@ -57,7 +57,7 @@ content:
     third_party_settings: {  }
   field_address:
     type: string_textfield
-    weight: 22
+    weight: 24
     region: content
     settings:
       size: 60
@@ -65,14 +65,14 @@ content:
     third_party_settings: {  }
   field_anonymous:
     type: boolean_checkbox
-    weight: 15
+    weight: 17
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_contacts:
     type: text_textarea
-    weight: 28
+    weight: 31
     region: content
     settings:
       rows: 5
@@ -80,14 +80,14 @@ content:
     third_party_settings: {  }
   field_copied:
     type: boolean_checkbox
-    weight: 39
+    weight: 44
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_employment:
     type: entity_reference_autocomplete
-    weight: 17
+    weight: 19
     region: content
     settings:
       match_operator: CONTAINS
@@ -97,7 +97,7 @@ content:
     third_party_settings: {  }
   field_employment_type:
     type: entity_reference_autocomplete
-    weight: 16
+    weight: 18
     region: content
     settings:
       match_operator: CONTAINS
@@ -107,14 +107,14 @@ content:
     third_party_settings: {  }
   field_image:
     type: media_library_widget
-    weight: 29
+    weight: 32
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   field_job_description_override:
     type: text_textarea_with_summary
-    weight: 42
+    weight: 29
     region: content
     settings:
       rows: 9
@@ -124,7 +124,7 @@ content:
     third_party_settings: {  }
   field_job_duration:
     type: string_textfield
-    weight: 21
+    weight: 23
     region: content
     settings:
       size: 60
@@ -132,20 +132,20 @@ content:
     third_party_settings: {  }
   field_jobs:
     type: number
-    weight: 14
+    weight: 16
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_last_changed_remote:
     type: datetime_default
-    weight: 35
+    weight: 40
     region: content
     settings: {  }
     third_party_settings: {  }
   field_link_to_application:
     type: link_default
-    weight: 19
+    weight: 21
     region: content
     settings:
       placeholder_url: ''
@@ -153,7 +153,7 @@ content:
     third_party_settings: {  }
   field_link_to_presentation:
     type: link_default
-    weight: 36
+    weight: 41
     region: content
     settings:
       placeholder_url: ''
@@ -161,7 +161,7 @@ content:
     third_party_settings: {  }
   field_organization:
     type: entity_reference_autocomplete
-    weight: 30
+    weight: 33
     region: content
     settings:
       match_operator: CONTAINS
@@ -171,7 +171,7 @@ content:
     third_party_settings: {  }
   field_organization_description:
     type: text_textarea
-    weight: 31
+    weight: 35
     region: content
     settings:
       rows: 5
@@ -179,7 +179,7 @@ content:
     third_party_settings: {  }
   field_organization_description_o:
     type: text_textarea
-    weight: 45
+    weight: 36
     region: content
     settings:
       rows: 5
@@ -187,95 +187,13 @@ content:
     third_party_settings: {  }
   field_organization_name:
     type: string_textfield
-    weight: 18
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_organization_override:
-    type: entity_reference_autocomplete
-    weight: 44
-    region: content
-    settings:
-      match_operator: CONTAINS
-      match_limit: 10
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_original_language:
-    type: options_select
-    weight: 40
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_postal_area:
-    type: string_textfield
-    weight: 24
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_postal_code:
-    type: string_textfield
-    weight: 23
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_prevent_publishing:
-    type: boolean_checkbox
-    weight: 13
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  field_publication_ends:
-    type: datetime_default
-    weight: 38
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_publication_starts:
-    type: datetime_default
-    weight: 37
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  field_recruitment_id:
-    type: string_textfield
-    weight: 25
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_recruitment_type:
-    type: number
-    weight: 33
-    region: content
-    settings:
-      placeholder: ''
-    third_party_settings: {  }
-  field_salary:
-    type: string_textfield
     weight: 20
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
-  field_salary_class:
-    type: string_textfield
-    weight: 27
-    region: content
-    settings:
-      size: 60
-      placeholder: ''
-    third_party_settings: {  }
-  field_task_area:
+  field_organization_override:
     type: entity_reference_autocomplete
     weight: 34
     region: content
@@ -285,16 +203,98 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_original_language:
+    type: options_select
+    weight: 45
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_postal_area:
+    type: string_textfield
+    weight: 26
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_postal_code:
+    type: string_textfield
+    weight: 25
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_prevent_publishing:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_publication_ends:
+    type: datetime_default
+    weight: 43
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_publication_starts:
+    type: datetime_default
+    weight: 42
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_recruitment_id:
+    type: string_textfield
+    weight: 27
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_recruitment_type:
+    type: number
+    weight: 38
+    region: content
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_salary:
+    type: string_textfield
+    weight: 22
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_salary_class:
+    type: string_textfield
+    weight: 30
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_task_area:
+    type: entity_reference_autocomplete
+    weight: 39
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
   field_video:
     type: media_library_widget
-    weight: 32
+    weight: 37
     region: content
     settings:
       media_types: {  }
     third_party_settings: {  }
   job_description:
     type: text_textarea_with_summary
-    weight: 26
+    weight: 28
     region: content
     settings:
       rows: 9
@@ -340,13 +340,13 @@ content:
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 11
+    weight: 13
     region: content
     settings:
       display_label: true
@@ -360,7 +360,7 @@ content:
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 12
+    weight: 14
     region: content
     settings:
       size: 60
@@ -388,7 +388,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.default.yml
@@ -60,7 +60,7 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 12
+    weight: 13
     region: content
   field_employment:
     type: entity_reference_label
@@ -87,14 +87,14 @@ content:
       image_loading:
         attribute: lazy
     third_party_settings: {  }
-    weight: 14
+    weight: 15
     region: content
   field_job_description_override:
     type: text_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 21
+    weight: 11
     region: content
   field_job_duration:
     type: string
@@ -126,7 +126,7 @@ content:
       rel: '0'
       target: '0'
     third_party_settings: {  }
-    weight: 13
+    weight: 14
     region: content
   field_organization:
     type: entity_reference_label
@@ -134,21 +134,21 @@ content:
     settings:
       link: false
     third_party_settings: {  }
-    weight: 15
+    weight: 16
     region: content
   field_organization_description:
     type: text_default
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 17
+    weight: 19
     region: content
   field_organization_description_o:
     type: text_default
-    label: above
+    label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 24
+    weight: 20
     region: content
   field_organization_name:
     type: string
@@ -160,11 +160,11 @@ content:
     region: content
   field_organization_override:
     type: entity_reference_label
-    label: above
+    label: hidden
     settings:
-      link: true
+      link: false
     third_party_settings: {  }
-    weight: 23
+    weight: 17
     region: content
   field_postal_area:
     type: string
@@ -189,7 +189,7 @@ content:
       timezone_override: ''
       format_type: publication_date_format
     third_party_settings: {  }
-    weight: 19
+    weight: 22
     region: content
   field_publication_starts:
     type: datetime_default
@@ -198,7 +198,7 @@ content:
       timezone_override: ''
       format_type: publication_date_format
     third_party_settings: {  }
-    weight: 18
+    weight: 21
     region: content
   field_recruitment_id:
     type: string
@@ -222,7 +222,7 @@ content:
     settings:
       link_to_entity: false
     third_party_settings: {  }
-    weight: 11
+    weight: 12
     region: content
   field_video:
     type: entity_reference_entity_view
@@ -231,7 +231,7 @@ content:
       view_mode: default
       link: true
     third_party_settings: {  }
-    weight: 16
+    weight: 18
     region: content
   job_description:
     type: text_default

--- a/conf/cmi/core.entity_view_display.node.job_listing.default.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.job_listing.field_employment
     - field.field.node.job_listing.field_employment_type
     - field.field.node.job_listing.field_image
+    - field.field.node.job_listing.field_job_description_override
     - field.field.node.job_listing.field_job_duration
     - field.field.node.job_listing.field_jobs
     - field.field.node.job_listing.field_last_changed_remote
@@ -17,7 +18,9 @@ dependencies:
     - field.field.node.job_listing.field_link_to_presentation
     - field.field.node.job_listing.field_organization
     - field.field.node.job_listing.field_organization_description
+    - field.field.node.job_listing.field_organization_description_o
     - field.field.node.job_listing.field_organization_name
+    - field.field.node.job_listing.field_organization_override
     - field.field.node.job_listing.field_original_language
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
@@ -86,6 +89,13 @@ content:
     third_party_settings: {  }
     weight: 14
     region: content
+  field_job_description_override:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 21
+    region: content
   field_job_duration:
     type: string
     label: hidden
@@ -133,6 +143,13 @@ content:
     third_party_settings: {  }
     weight: 17
     region: content
+  field_organization_description_o:
+    type: text_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 24
+    region: content
   field_organization_name:
     type: string
     label: hidden
@@ -140,6 +157,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 2
+    region: content
+  field_organization_override:
+    type: entity_reference_label
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    weight: 23
     region: content
   field_postal_area:
     type: string

--- a/conf/cmi/core.entity_view_display.node.job_listing.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.job_listing.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.job_listing.field_employment
     - field.field.node.job_listing.field_employment_type
     - field.field.node.job_listing.field_image
+    - field.field.node.job_listing.field_job_description_override
     - field.field.node.job_listing.field_job_duration
     - field.field.node.job_listing.field_jobs
     - field.field.node.job_listing.field_last_changed_remote
@@ -18,7 +19,9 @@ dependencies:
     - field.field.node.job_listing.field_link_to_presentation
     - field.field.node.job_listing.field_organization
     - field.field.node.job_listing.field_organization_description
+    - field.field.node.job_listing.field_organization_description_o
     - field.field.node.job_listing.field_organization_name
+    - field.field.node.job_listing.field_organization_override
     - field.field.node.job_listing.field_original_language
     - field.field.node.job_listing.field_postal_area
     - field.field.node.job_listing.field_postal_code
@@ -76,12 +79,15 @@ hidden:
   field_copied: true
   field_employment: true
   field_image: true
+  field_job_description_override: true
   field_jobs: true
   field_last_changed_remote: true
   field_link_to_application: true
   field_link_to_presentation: true
   field_organization: true
   field_organization_description: true
+  field_organization_description_o: true
+  field_organization_override: true
   field_original_language: true
   field_postal_area: true
   field_postal_code: true

--- a/conf/cmi/field.field.node.job_listing.field_job_description_override.yml
+++ b/conf/cmi/field.field.node.job_listing.field_job_description_override.yml
@@ -1,0 +1,33 @@
+uuid: 1d14aeec-cf74-4570-9ecc-380d33707c42
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_job_description_override
+    - node.type.job_listing
+  module:
+    - allowed_formats
+    - disable_field
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+  disable_field:
+    add_disable: none
+    edit_disable: roles
+    edit_roles:
+      - hr
+id: node.job_listing.field_job_description_override
+field_name: field_job_description_override
+entity_type: node
+bundle: job_listing
+label: 'Job description override'
+description: 'Override the job description.'
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/conf/cmi/field.field.node.job_listing.field_organization_description_o.yml
+++ b/conf/cmi/field.field.node.job_listing.field_organization_description_o.yml
@@ -1,0 +1,31 @@
+uuid: c804b2b7-217d-4600-894d-edd34b441576
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organization_description_o
+    - node.type.job_listing
+  module:
+    - allowed_formats
+    - disable_field
+    - text
+third_party_settings:
+  allowed_formats:
+    allowed_formats: {  }
+  disable_field:
+    add_disable: none
+    edit_disable: roles
+    edit_roles:
+      - hr
+id: node.job_listing.field_organization_description_o
+field_name: field_organization_description_o
+entity_type: node
+bundle: job_listing
+label: 'Organization description override'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/conf/cmi/field.field.node.job_listing.field_organization_description_o.yml
+++ b/conf/cmi/field.field.node.job_listing.field_organization_description_o.yml
@@ -22,7 +22,7 @@ field_name: field_organization_description_o
 entity_type: node
 bundle: job_listing
 label: 'Organization description override'
-description: ''
+description: 'Overrides the organization description. Concise description of the listing''s organization.'
 required: false
 translatable: true
 default_value: {  }

--- a/conf/cmi/field.field.node.job_listing.field_organization_override.yml
+++ b/conf/cmi/field.field.node.job_listing.field_organization_override.yml
@@ -1,0 +1,37 @@
+uuid: 17d0cffa-1dba-4b6a-a66f-b604eb3476df
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_organization_override
+    - node.type.job_listing
+    - taxonomy.vocabulary.organization
+  module:
+    - disable_field
+third_party_settings:
+  disable_field:
+    add_disable: none
+    edit_disable: roles
+    edit_roles:
+      - hr
+id: node.job_listing.field_organization_override
+field_name: field_organization_override
+entity_type: node
+bundle: job_listing
+label: 'Organization override'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      organization: organization
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.node.job_listing.field_organization_override.yml
+++ b/conf/cmi/field.field.node.job_listing.field_organization_override.yml
@@ -19,7 +19,7 @@ field_name: field_organization_override
 entity_type: node
 bundle: job_listing
 label: 'Organization override'
-description: ''
+description: 'Override job listing''s publishing organization.'
 required: false
 translatable: false
 default_value: {  }

--- a/conf/cmi/field.storage.node.field_job_description_override.yml
+++ b/conf/cmi/field.storage.node.field_job_description_override.yml
@@ -1,0 +1,19 @@
+uuid: f8ed4514-4bb2-412d-a5ae-fe1e26249185
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_job_description_override
+field_name: field_job_description_override
+entity_type: node
+type: text_with_summary
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_organization_description_o.yml
+++ b/conf/cmi/field.storage.node.field_organization_description_o.yml
@@ -1,0 +1,19 @@
+uuid: a27f2813-5323-468f-acae-255d316a7569
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_organization_description_o
+field_name: field_organization_description_o
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_organization_override.yml
+++ b/conf/cmi/field.storage.node.field_organization_override.yml
@@ -1,0 +1,20 @@
+uuid: 5be9439e-bc6f-4bb8-a2c0-282435a885b0
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_organization_override
+field_name: field_organization_override
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -23,7 +23,7 @@ function helfi_rekry_content_form_node_job_listing_edit_form_alter(array &$form,
   if (in_array('hr', $userRoles)) {
     $form['title']['#disabled'] = TRUE;
   }
-  
+
   // Fields that get data from TPR.
   $fields_from_tpr = [
     'field_salary_class',
@@ -56,10 +56,10 @@ function helfi_rekry_content_form_node_job_listing_edit_form_alter(array &$form,
   ];
 
   // Disable fields that get data from TPR.
-  foreach($fields_from_tpr as $field) {
+  foreach ($fields_from_tpr as $field) {
     $form[$field]['#disabled'] = TRUE;
   }
-  
+
 }
 
 /**

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -23,11 +23,43 @@ function helfi_rekry_content_form_node_job_listing_edit_form_alter(array &$form,
   if (in_array('hr', $userRoles)) {
     $form['title']['#disabled'] = TRUE;
   }
+  
+  // Fields that get data from TPR.
+  $fields_from_tpr = [
+    'field_salary_class',
+    'field_contacts',
+    'field_recruitment_id',
+    'field_last_changed_remote',
+    'field_recruitment_type',
+    'field_task_area',
+    'field_publication_ends',
+    'field_publication_starts',
+    'field_link_to_presentation',
+    'field_employment_type',
+    'job_description',
+    'field_organization_description',
+    'field_organization',
+    'field_jobs',
+    'field_organization_name',
+    'field_salary',
+    'field_job_duration',
+    'field_address',
+    'field_postal_code',
+    'field_postal_area',
+    'field_link_to_application',
+    'field_employment',
+    'field_image',
+    'field_video',
+    'field_copied',
+    'field_original_language',
+    'field_anonymous',
+  ];
 
-  // Make these fields disabled as they have separate override fields.
-  $form['field_organization']['#disabled'] = TRUE;
-  $form['field_organization_description']['#disabled'] = TRUE;
-  $form['job_description']['#disabled'] = TRUE;
+  // Disable fields that get data from TPR.
+  foreach($fields_from_tpr as $field) {
+    $form[$field]['#disabled'] = TRUE;
+  }
+  
 }
 
 /**

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -15,15 +15,19 @@ use Drupal\paragraphs\ParagraphInterface;
 
 /**
  * Implements hook_form_FORM_ID_alter().
- *
- * Disables title field for HR role when editing job listing node.
  */
 function helfi_rekry_content_form_node_job_listing_edit_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   $userRoles = \Drupal::currentUser()->getRoles();
 
+  // Disables title field for HR role when editing job listing node.
   if (in_array('hr', $userRoles)) {
     $form['title']['#disabled'] = TRUE;
   }
+
+  // Make these fields disabled as they have separate override fields.
+  $form['field_organization']['#disabled'] = TRUE;
+  $form['field_organization_description']['#disabled'] = TRUE;
+  $form['job_description']['#disabled'] = TRUE;
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -57,9 +57,16 @@ function hdbt_subtheme_preprocess_organization_information_block(array &$variabl
   $variables['content']['city_description_title'] = $job_listings_config->get('city_description_title');
   $variables['content']['city_description_text'] = $job_listings_config->get('city_description_text');
 
+  if (!empty($variables['elements']['field_organization_override']['#items'])) {
+    $organization_field = $variables['elements']['field_organization_override']['#items'];
+  }
+  else {
+    $organization_field = $variables["elements"]["field_organization"]["#items"];
+  }
+
   // Get organization.
-  if (!empty($variables["elements"]["field_organization"]["#items"])) {
-    $organization_id = $variables["elements"]["field_organization"]["#items"]->target_id;
+  if (!empty($organization_field)) {
+    $organization_id = $organization_field->target_id;
     $organization = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->load($organization_id);
   }
 
@@ -77,9 +84,12 @@ function hdbt_subtheme_preprocess_organization_information_block(array &$variabl
 
   // Set organization description from taxonomy term if it's missing from node.
   if (!empty($organization) && $node = \Drupal::routeMatch()->getParameter('node')) {
-    if ($node->field_organization_description->isEmpty() && !empty($org_description = $organization->getDescription())) {
-      $variables['content']['field_organization_description'] = strip_tags($org_description);
+    if (!$node->field_organization_description_o->isEmpty()) {
+      $variables['content']['field_organization_description'] = $variables['content']['field_organization_description_o'];
     }
+    elseif ($node->field_organization_description->isEmpty() && !empty($org_description = $organization->getDescription())) {
+      $variables['content']['field_organization_description'] = strip_tags($org_description);
+    }    
   }
 }
 

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -89,7 +89,7 @@ function hdbt_subtheme_preprocess_organization_information_block(array &$variabl
     }
     elseif ($node->field_organization_description->isEmpty() && !empty($org_description = $organization->getDescription())) {
       $variables['content']['field_organization_description'] = strip_tags($org_description);
-    }    
+    }
   }
 }
 

--- a/public/themes/custom/hdbt_subtheme/templates/block/organization-information-block.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/organization-information-block.html.twig
@@ -9,12 +9,16 @@
     {% endif %}
   </div>
   <div class="job-listing__organization-information">
-    {% if content.field_organization|render %}
+    {% if content.field_organization|render or content.field_organization_override|render %}
       <h2 class="job-listing__organization">
-        {{ content.field_organization }}
+        {% if content.field_organization_override %}
+          {{ content.field_organization_override }}
+        {% else %}
+          {{ content.field_organization }}
+        {% endif %}
       </h2>
     {% endif %}
-    {% if content.field_organization_description|render %}
+    {% if content.field_organization_description|render or content.field_organization_description_o|render %}
       <div class="job-listing__organization-description">
         {{ content.field_organization_description }}
       </div>

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -145,7 +145,11 @@
           {% include '@hdbt/misc/metadata-wrapper.twig' with { items: metadata }%}
         </div>
 
-        {{ content.job_description }}
+        {% if content.field_job_description_override|render %}
+          {{ content.field_job_description_override }}
+        {% else %}
+          {{ content.job_description }}
+        {% endif %}
         {{ content.field_salary_class }}
         {% if content.field_contacts|render or content.field_link_to_presentation|render %}
           <div class="job-listing__additional-information">


### PR DESCRIPTION
# [UHF-8476](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8476)
<!-- What problem does this solve? -->
Editors should be able to override some fields which come from TPR.

## What was done
<!-- Describe what was done -->

* Added override fields and use them.

## How to install

* Make sure your Rekry instance is up and running on correct branch.
  * `git checkout UHF-8476_Job-listing-overrides`
  * `make fresh`
* Run `make drush-cr drush-cim`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go view a job listing node. Check that the Job description, Organization and Organization description fields work (the ones that come from TPR).
* [ ] Fill the override fields mentioned in the previous step and check that the data is used on the job listing page.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review


[UHF-8476]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ