### PR TITLE
UHF-X: Fix organization title override sanity check

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/block/organization-information-block.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/block/organization-information-block.html.twig
@@ -11,7 +11,7 @@
   <div class="job-listing__organization-information">
     {% if content.field_organization|render or content.field_organization_override|render %}
       <h2 class="job-listing__organization">
-        {% if content.field_organization_override %}
+        {% if content.field_organization_override|render %}
           {{ content.field_organization_override }}
         {% else %}
           {{ content.field_organization }}


### PR DESCRIPTION
Fix sanity check for organization title override (previously was always true even when no value present)
