### PR TITLE
UHF-8241: Added format and function to convert line breaks to p tags.

### DIFF
--- a/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
@@ -142,7 +142,13 @@ process:
   langcode:
     plugin: default_value
     default_value: fi
-  job_description/value: job_description
+  job_description/value:
+    plugin: callback
+    callable: _filter_autop
+    source: job_description
+  job_description/format:
+    plugin: default_value
+    default_value: full_html
   field_address: address
   field_anonymous: anonymous
   field_contacts: contacts


### PR DESCRIPTION
# [UHF-8241](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8241)
<!-- What problem does this solve? -->
External links don't have the external link icons in job descriptions. Also, the formatting was lost after saving the node manually.

## What was done
<!-- Describe what was done -->

* Updated the migration process so that line breaks are converted to `<p>` and `<br>` tags.
* Added formatting so the links get icons.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8241_Job-description-formatting`
  * `make fresh`
* Run `make drush-cr`
* Run `drush migrate:import helfi_rekry_jobs:all --update`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Open a job listing that has external link in its job description (e.g. https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/kasko-01-1081-23).
* [x] Check that the external link has icon.
* [x] Try to manually save the node. Check that the external link still has the icon and the line breaks are working properly.

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8241]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ