### PR TITLE
UHF-8845: Add custom sitemap urls in en instead of fi

### DIFF
--- a/conf/cmi/simple_sitemap.custom_links.default.yml
+++ b/conf/cmi/simple_sitemap.custom_links.default.yml
@@ -4,93 +4,93 @@ links:
     priority: '1.0'
     changefreq: daily
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=32&page=1'
+    path: '/find-open-jobs?task_areas=32&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=33&page=1'
+    path: '/find-open-jobs?task_areas=33&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=34&page=1'
+    path: '/find-open-jobs?task_areas=34&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=35&page=1'
+    path: '/find-open-jobs?task_areas=35&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=36&page=1'
+    path: '/find-open-jobs?task_areas=36&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=37&page=1'
+    path: '/find-open-jobs?task_areas=37&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=240&page=1'
+    path: '/find-open-jobs?task_areas=240&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=241&page=1'
+    path: '/find-open-jobs?task_areas=241&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=242&page=1'
+    path: '/find-open-jobs?task_areas=242&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=253&page=1'
+    path: '/find-open-jobs?task_areas=253&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=255&page=1'
+    path: '/find-open-jobs?task_areas=255&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=256&page=1'
+    path: '/find-open-jobs?task_areas=256&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=257&page=1'
+    path: '/find-open-jobs?task_areas=257&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=258&page=1'
+    path: '/find-open-jobs?task_areas=258&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=982&page=1'
+    path: '/find-open-jobs?task_areas=982&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=984&page=1'
+    path: '/find-open-jobs?task_areas=984&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=985&page=1'
+    path: '/find-open-jobs?task_areas=985&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=986&page=1'
+    path: '/find-open-jobs?task_areas=986&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=987&page=1'
+    path: '/find-open-jobs?task_areas=987&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=981&page=1'
+    path: '/find-open-jobs?task_areas=981&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=1097&page=1'
+    path: '/find-open-jobs?task_areas=1097&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=1098&page=1'
+    path: '/find-open-jobs?task_areas=1098&page=1'
     priority: '1.0'
     changefreq: ''
   -
-    path: '/etsi-avoimia-tyopaikkoja?task_areas=1099&page=1'
+    path: '/find-open-jobs?task_areas=1099&page=1'
     priority: '1.0'


### PR DESCRIPTION
# [UHF-8845](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8845)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add custom sitemap urls in en instead of fi to fix custom sitemap url generation

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8845-fix-custom-sitemap-urls`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-rekry.docker.so/en/open-jobs/admin/config/search/simplesitemap/custom check that Default field has the correct values from [conf/cmi/simple_sitemap.custom_links.default.yml](https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/303/files#diff-53f8cf01447c2e684da6546d977c6f636b2da01894a6cc4565fe88a9fc9849bc) file.
* [ ] Check also if fi (https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/admin/config/search/simplesitemap/custom) ja sv versions of the page has the same custom urls (I'm not sure if it makes any difference? or should they have the fi and sv urls?)
* [ ] Check the sitemap: https://helfi-rekry.docker.so/sitemap.xml Does it have the urls with "task_areas" string in en, fi, and sv languages?
* [ ] Go back to: https://helfi-rekry.docker.so/en/open-jobs/admin/config/search/simplesitemap/custom and enable "Regenerate all sitemaps after hitting Save" field and submit the form. Does the submit work without errors about the urls? If you try to submit the form in fi page with en urls you should get the error message "The path /find-open-jobs?task_areas=32&page=1 does not exist."
* [ ] Check the sitemap again. Does it still have the urls with "task_areas" string in en, fi, and sv languages?
* [ ] Run `drush ssg`. Does it work or do you get these kind of warnings: `[warning] The custom path /etsi-avoimia-tyopaikkoja?task_areas=32&page=1 has been omitted from the XML sitemaps as it does not exist.`?
* [ ] Check the sitemap again. Does it still have the urls with "task_areas" string in en, fi, and sv languages?
* [ ] If drush command works without errors and sitemap also works after that, custom urls generation should also work with the cron runs. But I didn't have time to test this thoroughly, so pay attention to the custom urls in different languages settings.

[UHF-8845]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ