### PR TITLE
UHF-8946: redirect to existing job listing translation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,4 +65,4 @@ jobs:
       - name: Run PHPUnit tests
         run: |
           composer test-php public/modules/custom
-          [ -d "tests/" ] && composer test-php tests/ || echo "No DTT tests found. Ignoring..."
+          if [ -d "tests/" ]; then composer test-php tests/; else echo "No DTT tests found. Ignoring..."; fi

--- a/composer.lock
+++ b/composer.lock
@@ -3970,10 +3970,6 @@
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/issues"
             },
             "time": "2023-09-14T09:11:02+00:00"
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.5.3",
-                "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/issues"
-            },
-            "time": "2023-09-13T05:29:57+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",

--- a/composer.lock
+++ b/composer.lock
@@ -3931,16 +3931,16 @@
         },
         {
             "name": "drupal/helfi_api_base",
-            "version": "2.5.2",
+            "version": "2.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base.git",
-                "reference": "10f5700e4c38c403d2cc54d2733cadaff72d67c1"
+                "reference": "2a0a4fb2ea863232dc3eed32a3e8104fdffab178"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-api-base/zipball/10f5700e4c38c403d2cc54d2733cadaff72d67c1",
-                "reference": "10f5700e4c38c403d2cc54d2733cadaff72d67c1",
+                "url": "https://api.github.com/repos/City-of-Helsinki/drupal-module-helfi-api-base/zipball/2a0a4fb2ea863232dc3eed32a3e8104fdffab178",
+                "reference": "2a0a4fb2ea863232dc3eed32a3e8104fdffab178",
                 "shasum": ""
             },
             "require": {
@@ -3966,10 +3966,10 @@
             ],
             "description": "Helfi - API Base",
             "support": {
-                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.5.2",
+                "source": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/tree/2.5.4",
                 "issues": "https://github.com/City-of-Helsinki/drupal-module-helfi-api-base/issues"
             },
-            "time": "2023-09-08T09:03:20+00:00"
+            "time": "2023-09-14T09:11:02+00:00"
         },
         {
             "name": "drupal/helfi_azure_fs",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,7 @@
   <env name="DTT_MINK_DRIVER_ARGS" value='["chrome", {"chromeOptions":{"w3c": false }}, "http://127.0.0.1:4444"]'/>
   <env name="DTT_API_OPTIONS" value='{"socketTimeout": 360, "domWaitTimeout": 3600000}' />
   <env name="DTT_API_URL" value="http://127.0.0.1:9222"/>
-  <env name="DTT_BASE_URL" value="http://127.0.0.1:8080"/>
+  <env name="DTT_BASE_URL" value="http://127.0.0.1:8888"/>
 </php>
 <testsuites>
   <testsuite name="unit">

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.services.yml
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.services.yml
@@ -15,7 +15,7 @@ services:
       - { name: 'event_subscriber' }
   helfi_rekry_content.job_listing_redirect_subscriber:
     class: Drupal\helfi_rekry_content\EventSubscriber\JobListingRedirectSubscriber
-    arguments: ['@config.factory', '@current_user']
+    arguments: ['@config.factory', '@current_user', '@entity_type.manager']
     tags:
       - { name: 'event_subscriber' }
   logger.channel.helfi_rekry_content:

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -77,7 +77,7 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
   /**
    * The 404 exception listener.
    *
-   * #UHF-8946 External service's automation is only capable of creating links to
+   * #UHF8946 External service's automation is only capable of creating links to
    * finnish job listings. If finnish translation doesn't exist the user will be
    * automatically redirected to existing translation with matching job ID.
    *

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -95,9 +95,9 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
     // Since we are listening to 404 exception,
     // the node loaded is automatically existing translation.
     // We can just redirect without worrying whether the translation exists.
-    $response = new TrustedRedirectResponse(
-      $node->toUrl('canonical', ['language' => $node->language()])->toString(),
-    );
+    $url = $node->toUrl('canonical', ['language' => $node->language()])->toString();
+    $response = new TrustedRedirectResponse($url);
+    $response->addCacheableDependency($url);
     $event->setResponse($response);
   }
 

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace Drupal\helfi_rekry_content\EventSubscriber;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase;
 use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
@@ -27,7 +28,8 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
    */
   public function __construct(
     protected ConfigFactoryInterface $configFactory,
-    protected AccountInterface $currentUser
+    protected AccountInterface $currentUser,
+    protected EntityTypeManager $entityTypeManager,
   ) {}
 
   /**
@@ -73,10 +75,10 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
   /**
    * If trying to access non-existing translation, redirect to existing one.
    *
-   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
+   * @param ExceptionEvent $event
    *   The Event to process.
    */
-  public function on404(ExceptionEvent $event) {
+  public function on404(ExceptionEvent $event) : void {
     $uri = $event->getRequest()->getRequestUri();
     $redirectFrom = 'avoimet-tyopaikat/avoimet-tyopaikat/';
     if (!str_contains($uri, $redirectFrom)) {
@@ -84,7 +86,7 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
     }
 
     $recruitmentId = array_reverse(explode('/', $uri))[0];
-    $nodes = \Drupal::entityTypeManager()
+    $nodes = $this->entityTypeManager
       ->getStorage('node')
       ->loadByProperties(['field_recruitment_id' => $recruitmentId]);
 

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -6,10 +6,10 @@ namespace Drupal\helfi_rekry_content\EventSubscriber;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\EventSubscriber\HttpExceptionSubscriberBase;
+use Drupal\Core\Routing\TrustedRedirectResponse;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Url;
 use Drupal\node\NodeInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 /**
@@ -66,7 +66,7 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
     $url = Url::fromRoute('entity.node.canonical', ['node' => $redirectNode])->toString();
 
     // Set temporary redirect.
-    $response = new RedirectResponse($url, 307);
+    $response = new TrustedRedirectResponse($url, 307);
     $event->setResponse($response);
   }
 
@@ -95,9 +95,8 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
     // Since we are listening to 404 exception,
     // the node loaded is automatically existing translation.
     // We can just redirect without worrying whether the translation exists.
-    $response = new RedirectResponse(
+    $response = new TrustedRedirectResponse(
       $node->toUrl('canonical', ['language' => $node->language()])->toString(),
-      302
     );
     $event->setResponse($response);
   }

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -14,7 +14,7 @@ use Drupal\node\NodeInterface;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 
 /**
- * Redirect job listing 403s for anonymous users.
+ * Http exception event subscribers for job listings.
  */
 class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
 
@@ -75,7 +75,11 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
   }
 
   /**
-   * If trying to access non-existing translation, redirect to existing one.
+   * The 404 exception listener.
+   *
+   * #UHF-8946 External service's automation is only capable of creating links to
+   * finnish job listings. If finnish translation doesn't exist the user will be
+   * automatically redirected to existing translation with matching job ID.
    *
    * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
    *   The Event to process.

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -80,8 +80,21 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
    */
   public function on404(ExceptionEvent $event) : void {
     $uri = $event->getRequest()->getRequestUri();
-    $redirectFrom = 'avoimet-tyopaikat/avoimet-tyopaikat/';
-    if (!str_contains($uri, $redirectFrom)) {
+    $redirectPaths = [
+      'avoimet-tyopaikat/avoimet-tyopaikat/',
+      'lediga-jobb/lediga-jobb/',
+      'open-jobs/open-jobs/',
+    ];
+
+    $redirectFrom = NULL;
+    foreach($redirectPaths as $path) {
+      if (str_contains($uri, $path)) {
+        $redirectFrom = $path;
+        break;
+      }
+    }
+
+    if (!$redirectFrom) {
       return;
     }
 
@@ -94,9 +107,6 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
       return;
     }
 
-    // Since we are listening to 404 exception,
-    // the node loaded is automatically existing translation.
-    // We can just redirect without worrying whether the translation exists.
     $url = $node->toUrl('canonical', ['language' => $node->language()])->toString();
     $response = new TrustedRedirectResponse($url);
     $response->addCacheableDependency($url);

--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -25,6 +25,8 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
    *   The configuration factory.
    * @param \Drupal\Core\Session\AccountInterface $currentUser
    *   The current user.
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
+   *   The entity type manager.
    */
   public function __construct(
     protected ConfigFactoryInterface $configFactory,
@@ -75,19 +77,19 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
   /**
    * If trying to access non-existing translation, redirect to existing one.
    *
-   * @param ExceptionEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\ExceptionEvent $event
    *   The Event to process.
    */
   public function on404(ExceptionEvent $event) : void {
     $uri = $event->getRequest()->getRequestUri();
     $redirectPaths = [
-      'avoimet-tyopaikat/avoimet-tyopaikat/',
-      'lediga-jobb/lediga-jobb/',
-      'open-jobs/open-jobs/',
+      'fi' => 'avoimet-tyopaikat/avoimet-tyopaikat/',
+      'sv' => 'lediga-jobb/lediga-jobb/',
+      'en' => 'open-jobs/open-jobs/',
     ];
 
     $redirectFrom = NULL;
-    foreach($redirectPaths as $path) {
+    foreach ($redirectPaths as $path) {
       if (str_contains($uri, $path)) {
         $redirectFrom = $path;
         break;

--- a/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
+++ b/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
@@ -4,14 +4,16 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_rekry_content\Tests\dtt\src\ExistingSite;
 
-use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+
+use Drupal\Tests\helfi_api_base\Functional\ExistingSiteTestBase;
 
 /**
  * Test job listing redirect.
  *
  * @group dtt
  */
-class JoblistingRedirectTest extends ExistingSiteBase {
+class JoblistingRedirectTest extends ExistingSiteTestBase {
 
   /**
    * Test job listing 404 redirect.
@@ -27,7 +29,7 @@ class JoblistingRedirectTest extends ExistingSiteBase {
     $path = $node->toUrl()->toString();
     $recruitmentId = array_reverse(explode('/', $path))[0];
 
-    $this->drupalGet("/fi/avoimet-tyopaikat/avoimet-tyopaikat/$recruitmentId");
+    $this->drupalGetWithLanguage("/fi/avoimet-tyopaikat/avoimet-tyopaikat/$recruitmentId", 'fi');
     $url = $this->getSession()->getCurrentUrl();
     $this->assertTrue(str_ends_with($url, '/sv/lediga-jobb/lediga-jobb/testi-1234-56-7890'));
   }

--- a/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
+++ b/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace Drupal\helfi_rekry_content\Tests\dtt\src\ExistingSite;
+
+use weitzman\DrupalTestTraits\ExistingSiteBase;
+
+/**
+ * Test job listing redirect.
+ *
+ * @group dtt
+ */
+class JoblistingRedirectTest extends ExistingSiteBase {
+
+  /**
+   * Test job listing 404 redirect.
+   */
+  public function test404Redirect(): void {
+    $node = $this->createNode([
+      'type' => 'job_listing',
+      'langcode' => 'sv',
+      'title' => 'en jobb',
+      'field_recruitment_id' => 'TESTI-1234-56-7890'
+    ]);
+
+    $path = $node->toUrl()->toString();
+    $recruitmentId = array_reverse(explode('/', $path))[0];
+
+    $this->drupalGet("/fi/avoimet-tyopaikat/avoimet-tyopaikat/$recruitmentId");
+
+    $url = $this->getSession()->getCurrentUrl();
+
+    $this->assertTrue(str_ends_with($url, '/sv/lediga-jobb/lediga-jobb/testi-1234-56-7890'));
+  }
+
+}

--- a/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
+++ b/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
@@ -21,16 +21,14 @@ class JoblistingRedirectTest extends ExistingSiteBase {
       'type' => 'job_listing',
       'langcode' => 'sv',
       'title' => 'en jobb',
-      'field_recruitment_id' => 'TESTI-1234-56-7890'
+      'field_recruitment_id' => 'TESTI-1234-56-7890',
     ]);
 
     $path = $node->toUrl()->toString();
     $recruitmentId = array_reverse(explode('/', $path))[0];
 
     $this->drupalGet("/fi/avoimet-tyopaikat/avoimet-tyopaikat/$recruitmentId");
-
     $url = $this->getSession()->getCurrentUrl();
-
     $this->assertTrue(str_ends_with($url, '/sv/lediga-jobb/lediga-jobb/testi-1234-56-7890'));
   }
 

--- a/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
+++ b/public/modules/custom/helfi_rekry_content/tests/dtt/src/ExistingSite/JoblistingRedirectTest.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace Drupal\helfi_rekry_content\Tests\dtt\src\ExistingSite;
 
-
-
 use Drupal\Tests\helfi_api_base\Functional\ExistingSiteTestBase;
 
 /**


### PR DESCRIPTION
# [UHF-8946](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8946)
External system is only capable of creating links to finnish job listings. If job listing doesn't have finnish translation the user would see 404 page.

## What was done
Added 404 exception listener which redirect user from untranslated job listing to the existing translation if it exists.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8946_job_redirect`
  * `make fresh`
* Run `make drush-cr`


## How to test
- [Go to job listing](https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja) and use a filter to find a job with only swedish translation
- open the job
- manually change the url from `/sv/lediga-jobb/lediga-jobb/{job_recruitment_id}` to
  -  `/fi/avoimet-tyopaikat/avoimet-tyopaikat/{job_recruitment_id}`
- When you try to access finnish translation, you are redirected back to swedish translation.

Other things to try out:
- Test other translation combinations if possible
- Test paths starting with `/fi/avoimet-tyopaikat/avoimet-tyopaikat/`, for example non existing recruitment id


[UHF-8946]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ