### PR TITLE
UHF-8948: Modify Job listing index Search API processors

### DIFF
--- a/conf/cmi/search_api.index.job_listings.yml
+++ b/conf/cmi/search_api.index.job_listings.yml
@@ -268,7 +268,6 @@ field_settings:
     datasource_id: 'entity:node'
     property_path: title
     type: text
-    boost: !!float 2
     dependencies:
       module:
         - node
@@ -335,24 +334,12 @@ processor_settings:
       - field_recruitment_id
       - field_search_id
       - langcode
-      - title
   language_with_fallback: {  }
-  number_field_boost:
-    weights:
-      preprocess_index: 0
-    boosts: {  }
   project_execution_schedule: {  }
   project_image_absolute_url: {  }
   project_plan_schedule: {  }
   rendered_item: {  }
   reverse_entity_references: {  }
-  tokenizer:
-    all_fields: false
-    fields: {  }
-    spaces: ''
-    ignored: ._-
-    overlap_cjk: 1
-    minimum_word_size: '3'
 tracker_settings:
   default:
     indexing_order: fifo


### PR DESCRIPTION
# [UHF-8948](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8948)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Remove Ignore case Search API processor from Job listing title field to index title without lowercasing it
* Remove tokenizer and field boost processors from job_listing index as those are not used and Elastic 8 doesn't support index time boosting.

Check testing instructions from HDBT PR: https://github.com/City-of-Helsinki/drupal-hdbt/pull/778

[UHF-8948]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8948?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ