### PR TITLE
UHF-8702: Switched the code to 410 on unpublished job listings.

### DIFF
--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingRedirectSubscriber.php
@@ -69,8 +69,9 @@ class JobListingRedirectSubscriber extends HttpExceptionSubscriberBase {
 
     $url = Url::fromRoute('entity.node.canonical', ['node' => $redirectNode])->toString();
 
-    // Set temporary redirect.
-    $response = new TrustedRedirectResponse($url, 307);
+    // Set status code to 410.
+    $response = new TrustedRedirectResponse($url);
+    $response->setStatusCode(410);
     $event->setResponse($response);
   }
 


### PR DESCRIPTION
# [UHF-8702](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8702)
<!-- What problem does this solve? -->

Unpublished job applications are wanted to be removed from Google index quicker.

## What was done
<!-- Describe what was done -->

* Unpublished job applications now return 410 code.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8702_410-redirect`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/kasko-01-1161-23
* [ ] Check that the page first returns 410 and then redirects to the page telling that job application has been closed.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-8702]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ