### PR TITLE
UHF-9080 react fallback

### DIFF
--- a/conf/cmi/views.view.job_listing_search.yml
+++ b/conf/cmi/views.view.job_listing_search.yml
@@ -158,7 +158,44 @@ display:
             label: ''
             field_identifier: ''
           exposed: false
-      arguments: {  }
+      arguments:
+        field_task_area_target_id:
+          id: field_task_area_target_id
+          table: node__field_task_area
+          field: field_task_area_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: numeric
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: task_areas
+            fallback: all
+            multiple: and
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
       filters:
         status:
           id: status
@@ -182,51 +219,14 @@ display:
           plugin_id: bundle
           value:
             job_listing: job_listing
-          expose:
-            operator_limit_selection: false
-            operator_list: {  }
-        langcode:
-          id: langcode
-          table: node_field_data
-          field: langcode
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: langcode
-          plugin_id: language
-          operator: in
-          value:
-            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
           group: 1
-          exposed: false
           expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
             operator_limit_selection: false
             operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
       style:
         type: default
       row:
@@ -251,6 +251,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -267,6 +268,7 @@ display:
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions

--- a/conf/cmi/views.view.job_listing_search.yml
+++ b/conf/cmi/views.view.job_listing_search.yml
@@ -223,6 +223,48 @@ display:
           expose:
             operator_limit_selection: false
             operator_list: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
       filter_groups:
         operator: AND
         groups:

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -14,6 +14,8 @@ use Drupal\media\OEmbed\ResourceException;
 use Drupal\migrate\MigrateSkipRowException;
 use Drupal\node\NodeInterface;
 use Drupal\paragraphs\ParagraphInterface;
+use Drupal\views\Plugin\views\query\QueryPluginBase;
+use Drupal\views\ViewExecutable;
 
 /**
  * Implements hook_form_FORM_ID_alter().
@@ -435,4 +437,24 @@ function helfi_rekry_content_preprocess_block(&$variables) {
   if ($paragraph->getType() === 'job_listing_search') {
     $first_paragraph_gray = 'has-first-gray-bg-block';
   }
+}
+
+function helfi_rekry_content_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  $task_area_external_id = $query
+    ->where[0]["conditions"][0]["value"][":node__field_task_area_field_task_area_target_id"];
+
+  if (!$task_area_external_id) {
+    return;
+  }
+
+  /** @var \Drupal\taxonomy\Entity\Term $term */
+  $terms = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term')
+    ->loadByProperties(['field_external_id' => $task_area_external_id]);
+  if (!$terms) {
+    return;
+  }
+
+  $term = reset($terms);
+  $query->where[0]["conditions"][0]["value"][":node__field_task_area_field_task_area_target_id"] = $term->id();
 }

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -447,6 +447,10 @@ function helfi_rekry_content_views_query_alter(ViewExecutable $view, QueryPlugin
     return;
   }
 
+  if (!isset($query->where[0]["conditions"][0])) {
+    return;
+  }
+
   $task_area_external_id = $query
     ->where[0]["conditions"][0]["value"][":node__field_task_area_field_task_area_target_id"];
 

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -480,7 +480,7 @@ function helfi_rekry_content_views_query_alter(ViewExecutable $view, QueryPlugin
   $term = reset($terms);
   $query->where[0]["conditions"][0]["value"][":node__field_task_area_field_task_area_target_id"] = $term->id();
 }
- 
+
 /**
  * Implements hook_page_attachments().
  */

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -439,7 +439,14 @@ function helfi_rekry_content_preprocess_block(&$variables) {
   }
 }
 
+/**
+ * Implements hook_views_query_alter().
+ */
 function helfi_rekry_content_views_query_alter(ViewExecutable $view, QueryPluginBase $query) {
+  if ($view->id() !== 'job_listing_search') {
+    return;
+  }
+
   $task_area_external_id = $query
     ->where[0]["conditions"][0]["value"][":node__field_task_area_field_task_area_target_id"];
 


### PR DESCRIPTION
# [UHF-9080](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9080)
React fallback view should return correct values

## What was done
Added contextual filter to react fallback view
Added query alter to match the "external id" of task_area term to the actual TID used by drupal in order to make the drupal views query work.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9080`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Go to fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja
- Use the react search to generate query parameters for the fallback search
  - Apply "ammattiala"(task_area) filter  
  - Apply filters and check the result count 
- Disable javascript to see the fallback list with query parameters
  - Fallback should return (more or less*) the same amount of results as the react search. The result may 
- Add &page=2 filter manually. You should see different result.

*The result is a bit off and a ticket will be created to figure out why.

* [x] Check that this feature works
* [x] Check that code follows our standards

## Other PRs
https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/460


[UHF-9080]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ