### PR TITLE
UHF-8986: disallowed search query parameters

### DIFF
--- a/public/.gitignore
+++ b/public/.gitignore
@@ -8,7 +8,6 @@ README.txt
 autoload.php
 example.gitignore
 index.php
-robots.txt
 update.php
 web.config
 /README.md

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,73 @@
+#
+# robots.txt
+#
+# This file is to prevent the crawling and indexing of certain parts
+# of your site by web crawlers and spiders run by sites like Yahoo!
+# and Google. By telling these "robots" where not to go on your site,
+# you save bandwidth and server resources.
+#
+# This file will be ignored unless it is at the root of your host:
+# Used:    http://example.com/robots.txt
+# Ignored: http://example.com/site/robots.txt
+#
+# For more information about the robots.txt standard, see:
+# http://www.robotstxt.org/robotstxt.html
+
+User-agent: *
+# CSS, JS, Images
+Allow: /core/*.css$
+Allow: /core/*.css?
+Allow: /core/*.js$
+Allow: /core/*.js?
+Allow: /core/*.gif
+Allow: /core/*.jpg
+Allow: /core/*.jpeg
+Allow: /core/*.png
+Allow: /core/*.svg
+Allow: /profiles/*.css$
+Allow: /profiles/*.css?
+Allow: /profiles/*.js$
+Allow: /profiles/*.js?
+Allow: /profiles/*.gif
+Allow: /profiles/*.jpg
+Allow: /profiles/*.jpeg
+Allow: /profiles/*.png
+Allow: /profiles/*.svg
+# Directories
+Disallow: /core/
+Disallow: /profiles/
+# Files
+Disallow: /README.txt
+Disallow: /web.config
+# Paths (clean URLs)
+Disallow: /admin/
+Disallow: /comment/reply/
+Disallow: /filter/tips
+Disallow: /node/add/
+Disallow: /search/
+Disallow: /user/register
+Disallow: /user/password
+Disallow: /user/login
+Disallow: /user/logout
+Disallow: /media/oembed
+Disallow: /*/media/oembed
+# Paths (no clean URLs)
+Disallow: /index.php/admin/
+Disallow: /index.php/comment/reply/
+Disallow: /index.php/filter/tips
+Disallow: /index.php/node/add/
+Disallow: /index.php/search/
+Disallow: /index.php/user/password
+Disallow: /index.php/user/register
+Disallow: /index.php/user/login
+Disallow: /index.php/user/logout
+Disallow: /index.php/media/oembed
+Disallow: /index.php/*/media/oembed
+
+# Search page query parameters, task_areas and page are allowed.
+Disallow: /*?*employment=*
+Disallow: /*?*keyword=*
+Disallow: /*?*language=*
+Disallow: /*?*continuous=*
+Disallow: /*?*internship=*
+


### PR DESCRIPTION
# [UHF-8986](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8986)
<!-- What problem does this solve? -->

Less indexed urls for job search page.

## What was done

Added query parameters to robots.txt as disallowed

## How to install

Cannot be tested on local as far as I know

## How to test

Cannot be tested on local as far as I know

## Other PRs

[Etusivu](https://github.com/City-of-Helsinki/drupal-helfi-etusivu/pull/480) & [paatokset](https://github.com/City-of-Helsinki/helsinki-paatokset/pull/341)


[UHF-8986]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ