### PR TITLE
UHF-X: Error message must be a string

### DIFF
--- a/public/modules/custom/helfi_rekry_content/src/Plugin/migrate_plus/data_parser/HelbitJson.php
+++ b/public/modules/custom/helfi_rekry_content/src/Plugin/migrate_plus/data_parser/HelbitJson.php
@@ -69,7 +69,7 @@ class HelbitJson extends Json {
       return [];
     }
 
-    $this->logger->error($this->t('Failed retrieving data from Helbit. Request failed with code: @status_code'), [
+    $this->logger->error('Failed retrieving data from Helbit. Request failed with code: @status_code', [
       '@status_code' => $source_data['status'],
     ]);
 


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Job migration crashed if helbit credentials are not set since logger argument must be a string, not `TranslatableMarkup`.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review
* [ ] This PR has been visually reviewed by a designer (Name of the designer)