### PR TITLE
UHF-5253: Postal code field to index

### DIFF
--- a/conf/cmi/search_api.index.job_listings.yml
+++ b/conf/cmi/search_api.index.job_listings.yml
@@ -13,6 +13,7 @@ dependencies:
     - field.storage.node.field_organization_name
     - field.storage.node.field_original_language
     - field.storage.node.field_postal_area
+    - field.storage.node.field_postal_code
     - field.storage.node.field_promoted
     - field.storage.node.field_publication_starts
     - field.storage.node.field_recruitment_id
@@ -143,6 +144,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_postal_area
+  field_postal_code:
+    label: Postinumero
+    datasource_id: 'entity:node'
+    property_path: field_postal_code
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_postal_code
   field_promoted:
     label: Promoted
     datasource_id: 'entity:node'


### PR DESCRIPTION
# [UHF-5253](https://helsinkisolutionoffice.atlassian.net/browse/UHF-5253)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

*  Added Postal code field to index for location base search

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-5253_Job_location_filter`
  * `make fresh`
* Run `make shell`
* Run `drush sapi-c; drush sapi-rt; drush sapi-i; drush cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Open Elastic index `https://elastic-helfi-rekry.docker.so/job_listings`
* [ ] Check that index has `field_postal_code` with type of `keyword`
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [X] This PR does not need designers review

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/864


[UHF-5253]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ