### PR TITLE
Fix deprecation error in views-view--job-listing-search.html.twig

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--job-listing-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--job-listing-search.html.twig
@@ -55,8 +55,8 @@
   <div class="job-listing-search__results">
     <div class="job-listing-search__result-actions">
       <span class="job-listing-search__count-container">
-        <span class="job-listing-search__count">{{ total_rows }}</span>
-        {% trans with {'context': 'Job listing search count'}%}open job listing{% plural total_rows %}open job listings{% endtrans %}
+        <span class="job-listing-search__count">{{ total_rows ?? 0 }}</span>
+        {% trans with {'context': 'Job listing search count'}%}open job listing{% plural total_rows ?? 0 %}open job listings{% endtrans %}
       </span>
     </div>
     <div class="job-listing-search__result--list">


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

Log files are spammed with following message:

```
Deprecated function: abs(): Passing null to parameter #1 ($num) of type int|float is deprecated in __TwigTemplate_[...]->doDisplay() (line 95 of /tmp/twig/[...]_views-view--job-listing-[...].php)
```

This should fix the deprecation message.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-fix-deprecation-error`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that [this](https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja) page works without JS enabled.

