### PR TITLE
UHF-9587: Job migration fixes

### DIFF
--- a/docker/openshift/crons/migrate-changed-job-listings.sh
+++ b/docker/openshift/crons/migrate-changed-job-listings.sh
@@ -5,9 +5,9 @@ while true
 do
   echo "Running job listing:changed migrations: $(date)"
   # Allow migrations to be run every 15 minutes, reset stuck migrations every 12 hours.
-  drush migrate:import helfi_rekry_jobs:changed --update --reset-threshold 43200 --interval 900
-  drush migrate:import helfi_rekry_jobs:changed_sv --update --reset-threshold 43200 --interval 900
-  drush migrate:import helfi_rekry_jobs:changed_en --update --reset-threshold 43200 --interval 900
+  drush migrate:import helfi_rekry_jobs:changed --update --reset-threshold 43200 --interval 900 --no-progress
+  drush migrate:import helfi_rekry_jobs:changed_sv --update --reset-threshold 43200 --interval 900 --no-progress
+  drush migrate:import helfi_rekry_jobs:changed_en --update --reset-threshold 43200 --interval 900 --no-progress
 
   # Sleep for 30 minutes.
   sleep 1800

--- a/docker/openshift/crons/migrate-job-listings.sh
+++ b/docker/openshift/crons/migrate-job-listings.sh
@@ -5,17 +5,17 @@ while true
 do
   echo "Running job listing migrations: $(date)"
   # Allow migrations to be run every 1.5 hours, reset stuck migrations every 12 hours.
-  drush migrate:import helfi_rekry_images:all --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_videos:all --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_task_areas:all --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_task_areas:all_sv --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_task_areas:all_en --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_organizations:all --update --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_organizations:all_sv --update --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_organizations:all_en --update --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_jobs:all --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_jobs:all_sv --reset-threshold 43200 --interval 5400
-  drush migrate:import helfi_rekry_jobs:all_en --reset-threshold 43200 --interval 5400
+  drush migrate:import helfi_rekry_images:all --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_videos:all --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_task_areas:all --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_task_areas:all_sv --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_task_areas:all_en --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_organizations:all --update --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_organizations:all_sv --update --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_organizations:all_en --update --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_jobs:all --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_jobs:all_sv --reset-threshold 43200 --interval 5400 --no-progress
+  drush migrate:import helfi_rekry_jobs:all_en --reset-threshold 43200 --interval 5400 --no-progress
 
   drush helfi-rekry-content:clean-expired-listings
 

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -179,28 +179,31 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
       throw new MigrateSkipRowException();
     }
 
-    if (strpos($url, "://") === FALSE) {
+    if (!str_contains($url, "://")) {
       $url = "https://$url";
     }
 
     // Remove all extra query parameters from youtube link.
-    $querystring = parse_url($url, PHP_URL_QUERY);
     $queryParameters = [];
-    parse_str($querystring, $queryParameters);
-    if ($video_id = $queryParameters['v']) {
-      $parts = parse_url($url);
-      $path = $parts['path'];
-      $host = $parts['host'];
-      $scheme = $parts['scheme'] ? "{$parts['scheme']}://" : '';
-      $query = http_build_query([
-        'v' => $video_id,
-      ]);
-      $new_url = sprintf('%s%s%s?%s', $scheme, $host, rtrim($path, '/'), $query);
+    $querystring = parse_url($url, PHP_URL_QUERY);
+    if ($querystring) {
+      parse_str($querystring, $queryParameters);
 
-      \Drupal::logger('helfi_rekry_content')
-        ->notice('Updated remote video query parameters, new url: ' . $new_url);
+      if ($video_id = $queryParameters['v']) {
+        $parts = parse_url($url);
+        $path = $parts['path'];
+        $host = $parts['host'];
+        $scheme = $parts['scheme'] ? "{$parts['scheme']}://" : '';
+        $query = http_build_query([
+          'v' => $video_id,
+        ]);
+        $new_url = sprintf('%s%s%s?%s', $scheme, $host, rtrim($path, '/'), $query);
 
-      return $new_url;
+        \Drupal::logger('helfi_rekry_content')
+          ->notice('Updated remote video query parameters, new url: ' . $new_url);
+
+        return $new_url;
+      }
     }
 
     \Drupal::logger('helfi_rekry_content')

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -159,7 +159,9 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
     $provider = $resolver->getProviderByUrl($url);
   }
   catch (\throwable $e) {
-    \Drupal::logger('helfi_rekry_content')->notice('Video embed url "' . $url . '" failed validation with message: ' . $e->getMessage());
+    \Drupal::logger('helfi_rekry_content')
+      ->notice('Video embed url "' . $url . '" failed validation with message: ' . $e->getMessage());
+
     throw new MigrateSkipRowException();
   }
 
@@ -177,10 +179,6 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
       \Drupal::logger('helfi_rekry_content')
         ->error('Bad video url rejected by oembed-validation: ' . $url);
       throw new MigrateSkipRowException();
-    }
-
-    if (!str_contains($url, "://")) {
-      $url = "https://$url";
     }
 
     // Remove all extra query parameters from youtube link.
@@ -202,6 +200,8 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
         \Drupal::logger('helfi_rekry_content')
           ->notice('Updated remote video query parameters, new url: ' . $new_url);
 
+        // @fixme modifying the url here breaks lookup in helfi_rekry_jobs
+        // migration.
         return $new_url;
       }
     }
@@ -210,6 +210,32 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
       ->error('Bad video url rejected by oembed-validation: ' . $url);
     throw new MigrateSkipRowException();
   }
+}
+
+/**
+ * Sanitize video url.
+ *
+ * @param string $url
+ *   Previous video url.
+ *
+ * @returns string
+ *   New video url.
+ */
+function _helfi_rekry_content_sanitize_video_url(string $url): string {
+  if (!$url || !($url = trim($url))) {
+    return $url;
+  }
+
+  if (!str_contains($url, "://")) {
+    $url = "https://$url";
+  }
+
+  // OEmbed does not accept YouTube embed links.
+  if (preg_match("/youtube\.com\/embed\/([\w\-_]+)$/", $url, $matches)) {
+    $url = sprintf("https://youtube.com/watch?v=%s", $matches[1]);
+  }
+
+  return $url;
 }
 
 /**

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -155,8 +155,7 @@ function _helfi_rekry_content_get_media_image(string|NULL $fid = NULL): ?string 
 function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
   try {
     $resolver = \Drupal::service('media.oembed.url_resolver');
-    /** @var \Drupal\media\OEmbed\Provider $provider */
-    $provider = $resolver->getProviderByUrl($url);
+    $resolver->getProviderByUrl($url);
   }
   catch (\throwable $e) {
     \Drupal::logger('helfi_rekry_content')
@@ -175,39 +174,9 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
   }
   catch (ResourceException | ProviderException $e) {
     // fetchResource fails, the link is no good.
-    if (!str_contains(strtolower($provider->getName()), 'youtube')) {
-      \Drupal::logger('helfi_rekry_content')
-        ->error('Bad video url rejected by oembed-validation: ' . $url);
-      throw new MigrateSkipRowException();
-    }
-
-    // Remove all extra query parameters from youtube link.
-    $queryParameters = [];
-    $querystring = parse_url($url, PHP_URL_QUERY);
-    if ($querystring) {
-      parse_str($querystring, $queryParameters);
-
-      if ($video_id = $queryParameters['v']) {
-        $parts = parse_url($url);
-        $path = $parts['path'];
-        $host = $parts['host'];
-        $scheme = $parts['scheme'] ? "{$parts['scheme']}://" : '';
-        $query = http_build_query([
-          'v' => $video_id,
-        ]);
-        $new_url = sprintf('%s%s%s?%s', $scheme, $host, rtrim($path, '/'), $query);
-
-        \Drupal::logger('helfi_rekry_content')
-          ->notice('Updated remote video query parameters, new url: ' . $new_url);
-
-        // @fixme modifying the url here breaks lookup in helfi_rekry_jobs
-        // migration.
-        return $new_url;
-      }
-    }
-
     \Drupal::logger('helfi_rekry_content')
       ->error('Bad video url rejected by oembed-validation: ' . $url);
+
     throw new MigrateSkipRowException();
   }
 }

--- a/public/modules/custom/helfi_rekry_content/migrations/job_listing_videos.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listing_videos.yml
@@ -45,12 +45,18 @@ process:
       source: video
     -
       plugin: callback
+      callable: _helfi_rekry_content_sanitize_video_url
+      source: video
+    -
+      plugin: callback
       callable: _helfi_rekry_content_check_video_existance
+    -
+      plugin: callback
+      callable: _helfi_rekry_content_sanitize_video_url
       source: video
     -
       plugin: callback
       callable: _helfi_rekry_content_get_video_url
-      source: video
   langcode:
     plugin: default_value
     default_value: fi

--- a/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
@@ -196,9 +196,13 @@ process:
     plugin: default_value
     default_value: null
   field_video/target_id:
-    plugin: callback
-    callable: _helfi_rekry_content_lookup_video_mid
-    source: video
+    -
+      plugin: callback
+      callable: _helfi_rekry_content_sanitize_video_url
+      source: video
+    -
+      plugin: callback
+      callable: _helfi_rekry_content_lookup_video_mid
   field_organization_name: organization_name
   field_postal_area: postal_area
   field_postal_code: postal_code


### PR DESCRIPTION
# [UHF-9587](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9587)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Video field validation crashes for youtu.be links if the video is deleted

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9587-job-migration-fixes`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] `drush migrate:import helfi_rekry_videos:all  --reset-threshold 1` should complete without errors.
* [x] `drush migrate:import helfi_rekry_jobs:all --reset-threshold 1 --update` should complete without errors.
* [x] Video import should work for https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/kymp-04-1-24.
* [x] Check that code follows our standards



[UHF-9587]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9587?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ