### PR TITLE
UHF-9764: Remove unsupported videos from job listings 

### DIFF
--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
@@ -294,7 +294,8 @@ function helfi_rekry_content_update_9008() {
   $medias = Media::loadMultiple($ids);
   $storage_handler = \Drupal::entityTypeManager()->getStorage("media");
 
-  foreach ($medias as $media) {
+  foreach ($ids as $id) {
+    $media = Media::load($id);
     $url = $media->get('field_media_oembed_video')->value;
 
     if (str_contains($url, 'dreambroker')) {

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
@@ -283,7 +283,7 @@ function helfi_rekry_content_update_9007() {
 function helfi_rekry_content_update_9008() {
   $query = \Drupal::entityQuery('media')
     ->accessCheck(FALSE)
-    ->condition('bundle','remote_video');
+    ->condition('bundle', 'remote_video');
 
   $ids = $query->execute();
 
@@ -291,7 +291,6 @@ function helfi_rekry_content_update_9008() {
     return;
   }
 
-  $medias = Media::loadMultiple($ids);
   $storage_handler = \Drupal::entityTypeManager()->getStorage("media");
 
   foreach ($ids as $id) {
@@ -301,7 +300,7 @@ function helfi_rekry_content_update_9008() {
     if (str_contains($url, 'dreambroker')) {
       $query = \Drupal::entityQuery('node')
         ->accessCheck(FALSE)
-        ->condition('type','job_listing')
+        ->condition('type', 'job_listing')
         ->condition('field_video', '', '<>');
 
       $job_listing_nodes = $query->execute();

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
@@ -5,6 +5,7 @@
  * Contains install functions for HELfi Rekry Content module.
  */
 
+use Drupal\media\Entity\Media;
 use Drupal\migrate\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
 use Drupal\search_api\Entity\Index;
@@ -274,4 +275,45 @@ function helfi_rekry_content_update_9007() {
   // Mark index to require reindexing.
   $dispatcher = \Drupal::getContainer()->get('event_dispatcher');
   $dispatcher->dispatch(new ReindexScheduledEvent($jobIndex, TRUE), SearchApiEvents::REINDEX_SCHEDULED);
+}
+
+/**
+ * UHF-9764 Remove all videos with dreambroker provider.
+ */
+function helfi_rekry_content_update_9008() {
+  $query = \Drupal::entityQuery('media')
+    ->accessCheck(FALSE)
+    ->condition('bundle','remote_video');
+
+  $ids = $query->execute();
+
+  if (count($ids) === 0) {
+    return;
+  }
+
+  $medias = Media::loadMultiple($ids);
+  $storage_handler = \Drupal::entityTypeManager()->getStorage("media");
+
+  foreach ($medias as $media) {
+    $url = $media->get('field_media_oembed_video')->value;
+
+    if (str_contains($url, 'dreambroker')) {
+      $query = \Drupal::entityQuery('node')
+        ->accessCheck(FALSE)
+        ->condition('type','job_listing')
+        ->condition('field_video', '', '<>');
+
+      $job_listing_nodes = $query->execute();
+
+      foreach ($job_listing_nodes as $job_listing_node) {
+        $node = \Drupal::entityTypeManager()->getStorage('node')->load($job_listing_node);
+        $referenced_id = $node->get('field_video')?->first()?->get('entity')?->getValue()->id();
+
+        if ($referenced_id === $media->id()) {
+          $node->set('field_video', []);
+        }
+      }
+      $storage_handler->delete([$media]);
+    }
+  }
 }

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -153,6 +153,8 @@ function _helfi_rekry_content_get_media_image(string|NULL $fid = NULL): ?string 
  * @throws \Drupal\migrate\MigrateSkipRowException
  */
 function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
+
+
   try {
     $resolver = \Drupal::service('media.oembed.url_resolver');
     $resolver->getProviderByUrl($url);

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -153,8 +153,6 @@ function _helfi_rekry_content_get_media_image(string|NULL $fid = NULL): ?string 
  * @throws \Drupal\migrate\MigrateSkipRowException
  */
 function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
-
-
   try {
     /** @var \Drupal\media\OEmbed\UrlResolverInterface $resolver */
     $resolver = \Drupal::service('media.oembed.url_resolver');

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -163,7 +163,7 @@ function _helfi_rekry_content_get_video_url(string|NULL $url = NULL): ?string {
       throw new MigrateSkipRowException();
     }
   }
-  catch (\throwable $e) {
+  catch (ResourceException | ProviderException $e) {
     \Drupal::logger('helfi_rekry_content')
       ->notice('Video embed url "' . $url . '" failed validation with message: ' . $e->getMessage());
 

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -210,7 +210,7 @@ function hdbt_subtheme_preprocess_node(&$variables): void {
     }
   }
 
-  // Check if there is dreambroker urls on the media referred on the field video.
+  // Check if there are dreambroker urls on the referred media.
   if ($video = $node->get('field_video')?->first()?->get('entity')?->getValue()) {
     $url = $video->get('field_media_oembed_video')->value;
     if (str_contains($url, 'dreambroker')) {

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -209,6 +209,13 @@ function hdbt_subtheme_preprocess_node(&$variables): void {
       $variables['task_area_rekry_search_url'] = Url::fromRoute('entity.node.canonical', ['node' => $search_page_nid], $options);
     }
   }
+
+  if ($video = $node->get('field_video')?->first()?->get('entity')?->getValue()) {
+    $url = $video->get('field_media_oembed_video')->value;
+    if (str_contains($url, 'dreambroker')) {
+      $variables['unsupported_video'] = TRUE;
+    }
+  }
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -210,6 +210,7 @@ function hdbt_subtheme_preprocess_node(&$variables): void {
     }
   }
 
+  // Check if there is dreambroker urls on the media referred on the field video.
   if ($video = $node->get('field_video')?->first()?->get('entity')?->getValue()) {
     $url = $video->get('field_media_oembed_video')->value;
     if (str_contains($url, 'dreambroker')) {

--- a/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
+++ b/public/themes/custom/hdbt_subtheme/hdbt_subtheme.theme
@@ -209,14 +209,6 @@ function hdbt_subtheme_preprocess_node(&$variables): void {
       $variables['task_area_rekry_search_url'] = Url::fromRoute('entity.node.canonical', ['node' => $search_page_nid], $options);
     }
   }
-
-  // Check if there are dreambroker urls on the referred media.
-  if ($video = $node->get('field_video')?->first()?->get('entity')?->getValue()) {
-    $url = $video->get('field_media_oembed_video')->value;
-    if (str_contains($url, 'dreambroker')) {
-      $variables['unsupported_video'] = TRUE;
-    }
-  }
 }
 
 /**

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -186,7 +186,7 @@
           </div>
         {% endif %}
 
-        {% if content.field_video|render and not unsupported_video %}
+        {% if content.field_video|render %}
           <div class="job-listing__video job-listing__item">
             {% include '@hdbt/component/remote-video.twig' with {
               video: content.field_video,

--- a/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/layout/node--job-listing.html.twig
@@ -186,7 +186,7 @@
           </div>
         {% endif %}
 
-        {% if content.field_video|render %}
+        {% if content.field_video|render and not unsupported_video %}
           <div class="job-listing__video job-listing__item">
             {% include '@hdbt/component/remote-video.twig' with {
               video: content.field_video,


### PR DESCRIPTION
# [UHF-9764](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9764)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Add check for field_video on job listing not to render dream broker videos because they don't work.
* Add check for job listing migration to skip video providers other than YouTube or Helsinki Kanava (Icareus Suite).
* Remove the `_helfi_rekry_content_check_video_existance` function because it seems unnecessary.

## How to install

* Make sure your instance is up and running on correct branch. I recommend to take the latest database to your local so that you have the content for testing available.
  * `git checkout UHF-9764`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/palke-03-13-24 and make sure there is no video rendered on the job listing anymore. It used to have broken one like it has in production: https://www.hel.fi/fi/avoimet-tyopaikat/avoimet-tyopaikat/palke-03-13-24
* [ ] Check also that here https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/sotepe-03-279-24 the video is still visible.
* [ ] Go to shell on your rekry instance and run `drush migrate:import helfi_rekry_videos:all --update --reset-threshold 1` and the migration should throw you exceptions on dreambroker url(s). You might need helbit_client_id for the local settings if you don't have it set. Ask this from Tero or Santeri if you need it.
* [ ] Check that code follows our standards

## Designers review
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [x] This PR does not need designers review

[UHF-9764]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ