### PR TITLE
UHF-10080: added hakuvahti external network for drupal

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -37,6 +37,7 @@ services:
     networks:
       - internal
       - stonehenge-network
+      - hakuvahti_hav-network
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-app.entrypoints=https"
@@ -144,6 +145,8 @@ networks:
   internal:
     external: false
   stonehenge-network:
+    external: true
+  hakuvahti_hav-network:
     external: true
 
 volumes:


### PR DESCRIPTION
In order to make it work in docker, you still need to change the code to use the container names to send requests (on local environment).