### PR TITLE
UHF-10004 Fix for unsubscribe translation

### DIFF
--- a/public/modules/custom/helfi_hakuvahti/src/Controller/HelfiHakuvahtiUnsubscribeController.php
+++ b/public/modules/custom/helfi_hakuvahti/src/Controller/HelfiHakuvahtiUnsubscribeController.php
@@ -134,14 +134,10 @@ final class HelfiHakuvahtiUnsubscribeController extends ControllerBase {
   private function buildConfirmation(): array {
     $build = [];
 
-    $build['confirmation'] = [
-      '#title' => $this->t('The saved search has been deleted', [], ['context' => 'Hakuvahti']),
-    ];
-
     $build['confirmation']['paragraph'] = [
       '#type' => 'html_tag',
       '#tag' => 'p',
-      '#value' => $this->t('The saved search has been deleted'),
+      '#value' => $this->t('The saved search has been deleted', [], ['context' => 'Hakuvahti']),
       '#attributes' => [
         'class' => ['page-title'],
       ],


### PR DESCRIPTION
# [UHF-10004](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10004)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* There was one untranslated string in unsubscribe form. Fixed the form.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10004_fix_for_unsubscribe_translation`
  * `make drush-cr`
* Also make sure you are running hakuvahti branch on hdbt and main branch on hakuvahti server.

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that unsubscription form is now translated correctly.
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR
