### PR TITLE
UHF-9830: add a new mechanism to allow enriching mobile menu

### DIFF
--- a/conf/cmi/helfi_navigation.settings.yml
+++ b/conf/cmi/helfi_navigation.settings.yml
@@ -1,0 +1,1 @@
+global_navigation_enabled: false


### PR DESCRIPTION
# [UHF-9830](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9830)
Rekry is not part of global navigation and didn't have the credentials required by the global navigation. The mobile menu uses the lack of credentials as a way to determinate if a global navigation or enriched menu should be shown on mobile menu. Now that Rekry has the credential, the logic is broken


## What was done
Added a way tell that a site is not part of global navigation by adding module specific configuration file

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9830`
  * `make fresh`
* Update the module
  * `composer require drupal/helfi_navigation:dev-UHF-9830`
* Run `make drush-cr`

## How to test
- Go to any page (other than job search or frontpage)
  - for example `fi/avoimet-tyopaikat/opiskelijoille-ja-harjoittelijoille`
- Set your browser in mobile size
- Open mobile menu
- You should see the current page in the mobile menu
  - You can compare the menu to the production site and see the difference 

- Maybe test on other environment, like Sote, where global navigation should work "normally"

* [x] Check that this feature works
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Other PRs
* Link to other PR](https://github.com/City-of-Helsinki/drupal-module-helfi-navigation/pull/57)


[UHF-9830]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ