### PR TITLE
UHF-10102: Change local ELASTIC_PROXY_URL variable to use nginx proxy

### DIFF
--- a/.env
+++ b/.env
@@ -28,7 +28,7 @@ DRUPAL_WEBROOT=public
 HELBIT_CLIENT_ID=
 
 # URL for Elasticsearch (for job search)
-ELASTIC_PROXY_URL=https://elastic-helfi-rekry.docker.so
+ELASTIC_PROXY_URL=https://elastic-proxy-helfi-rekry.docker.so
 
 # Hakuvahti URL
 HAKUVAHTI_URL=http://helfi-rekry.docker.so:3000


### PR DESCRIPTION
# [UHF-10102](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10102)

## What was done
Changes local ELASTIC_PROXY_URL environment variable to use nginx proxy instead of the local elasticsearch service.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10102-change-elastic-proxy-url`
  * `make up` (to make sure the new environment variable updates)
  * `make fresh`
* Install the correct HDBT branch: `composer require drupal/hdbt:dev-UHF-10102-support-elastic-nginx-proxy`
* Run `make drush-cr`
* Reindex all content: `drush sapi-c;drush sapi-rt;drush sapi-i`

## How to test
* [x] Check that the nginx proxy URL works: https://elastic-proxy-helfi-rekry.docker.so/job_listings/_search 
* [x] Check that this feature works: https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja
  * [ ] Test with multiple filter and query combinations 
  * [ ] Check that the search app works on other languages too
* [x] Check that code follows our standards

## Continuous documentation
* [x] This feature has been documented/the documentation has been updated

## Other PRs
* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1007
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/652
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/889
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/851
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/499
* https://github.com/City-of-Helsinki/helsinki-paatokset/pull/425

[UHF-10102]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ