### PR TITLE
UHF-10408: Fixed migration image destination, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,15 @@ listings are published for indexing.
 - The migration interval for changed job listings poll is written on this cron configuration [here](https://github.com/City-of-Helsinki/drupal-helfi-rekry/blob/dev/docker/openshift/crons/migrate-changed-job-listings.sh).
 - The scheduled publishing interval can be checked from this cron configuration [here](https://github.com/City-of-Helsinki/drupal-helfi-rekry/blob/dev/docker/openshift/crons/content-scheduler.sh).
 
+### Testing on local
+
+The `job_listing_images` migration requires Azure Blob storage to be configured. See [Azure FS module](https://github.com/City-of-Helsinki/drupal-module-helfi-azure-fs?tab=readme-ov-file#testing-on-local) for more information.
+
+Modify/create `public/sites/default/local.settings.php` file with:
+```php
+$config['helfi_rekry_content.settings']['helbit_client_id'] = '[ copy value from HELBIT_CLIENT_ID environment variable ]';
+```
+
 ### Hakuvahti
 
 _Hakuvahti_ is feature of the [Job search](#job-search-job_search) that allows users to save their job search criteria. Users will

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -110,7 +110,10 @@ function _helfi_rekry_content_filename(?string $sourceUri = NULL): ?string {
   if (!$sourceUri) {
     return NULL;
   }
+  // Parse the filename from given URL. The url is something like:
+  // https://helbit.fi/portal-api/recruitment/images/L%C3%A4%C3%A4k%C3%A4ri_sairaanhoitaja_k%C3%A4yt%C3%A4v%C3%A4ll%C3%A4.png?target=1&id=26398.
   $filename = urldecode(strtok(basename($sourceUri), '?'));
+  // Transliterate and normalize the filename.
   $filename = str_replace(['ä', 'ö', 'å'], ['a', 'o', 'aa'], strtolower($filename));
   return preg_replace('/[ +]/', '_', $filename);
 }

--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.module
@@ -106,12 +106,13 @@ function helfi_rekry_content_scheduler_allow_publishing(NodeInterface $node): bo
  * @return string|null
  *   Filename or null
  */
-function _helfi_rekry_content_filename(string|NULL $sourceUri = NULL): ?string {
+function _helfi_rekry_content_filename(?string $sourceUri = NULL): ?string {
   if (!$sourceUri) {
     return NULL;
   }
-
-  return strtok(basename($sourceUri), '?');
+  $filename = urldecode(strtok(basename($sourceUri), '?'));
+  $filename = str_replace(['ä', 'ö', 'å'], ['a', 'o', 'aa'], strtolower($filename));
+  return preg_replace('/[ +]/', '_', $filename);
 }
 
 /**

--- a/public/modules/custom/helfi_rekry_content/migrations/job_listing_images.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listing_images.yml
@@ -35,7 +35,7 @@ source:
       label: Title
       selector: jobAdvertisement/title
   constants:
-    DRUPAL_FILE_DIRECTORY: 'public://job_listing_images/'
+    DRUPAL_FILE_DIRECTORY: 'azure://job_listing_images/'
     HELBIT_BASE_URL: 'https://helbit.fi'
 process:
   destination_filename:
@@ -70,7 +70,7 @@ process:
       source:
         - '@source_uri'
         - '@destination_path'
-      file_exists: rename
+      file_exists: use_existing
       move: false
   langcode: langcode
 destination:

--- a/public/modules/custom/helfi_rekry_content/tests/src/Kernel/FilenameTest.php
+++ b/public/modules/custom/helfi_rekry_content/tests/src/Kernel/FilenameTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_rekry_content\Kernel;
+
+use Drupal\KernelTests\KernelTestBase;
+
+/**
+ * Tests file name transliteration.
+ *
+ * @group helfi_rekry_content
+ */
+class FilenameTest extends KernelTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = ['helfi_rekry_content', 'content_lock'];
+
+  /**
+   * Tests the file name transliteration.
+   *
+   * @dataProvider filenameData
+   */
+  public function testFileName(?string $expectedFilename, ?string $filename) : void {
+    $this->assertEquals($expectedFilename, _helfi_rekry_content_filename($filename));
+  }
+
+  /**
+   * The data provider for file name tests.
+   *
+   * @return array
+   *   The data.
+   */
+  public function filenameData(): array {
+    return [
+      [
+        NULL,
+        NULL,
+      ],
+      [
+        'laakari_sairaanhoitaja_kaytavalla.png',
+        'https://helbit.fi/portal-api/recruitment/images/L%C3%A4%C3%A4k%C3%A4ri_sairaanhoitaja_k%C3%A4yt%C3%A4v%C3%A4ll%C3%A4.png?target=1&id=26398',
+      ],
+      [
+        'arabian_peruskoulu_30082023_kuva_maija_astikainen-5565-edit_pieni.jpg',
+        'https://helbit.fi/portal-api/recruitment/images/arabian_peruskoulu_30082023_kuva_maija_astikainen-5565-Edit_pieni.jpg?target=1&id=27012',
+      ],
+    ];
+  }
+
+}


### PR DESCRIPTION
## How to install

- `git checkout UHF-10408`
- `drush cr`
- See readme.md changes for how to setup Azure blob storage and required helbit configuration

## How to test
- [ ] Make sure `public/sites/default/files/job_listing_images` folder is empty/does not exist
- [ ] Run `drush mim helfi_rekry_images:all`
- [ ] Make sure the same folder is still empty