### PR TITLE
UHF-8706

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,11 @@ local site.
 4. To test the functionality, you should use the Mailpit running on your local in the `https://mailpit.docker.so/` url
 to view the emails being sent by the feature.
 
+#### Google indexing api automation (helfi_google_api-module)
+
+Job listing urls are automatically sent to google indexing api
+on publish and unpublish events, a request is sent to google to either index or deindex the url.
+
 ## Customizations
 
 ### Not part of global navigation

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "drupal/migrate_plus": "^6.0",
         "drupal/raven": "^5.0",
         "drupal/redis": "^1.5",
-        "drush/drush": "^12"
+        "drush/drush": "^12",
+        "google/apiclient": "^2.17"
     },
     "require-dev": {
         "donatj/mock-webserver": "^2.4",
@@ -99,7 +100,10 @@
         },
         "patchLevel": {
             "drupal/core": "-p2"
-        }
+        },
+        "google/apiclient-services": [
+            "Indexing"
+        ]
     },
     "repositories": [
         {
@@ -121,6 +125,7 @@
         "copy-commit-message-script": "make copy-commit-message-script",
         "post-install-cmd": [
             "@copy-commit-message-script"
-        ]
+        ],
+        "pre-autoload-dump": "Google\\Task\\Composer::cleanup"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5289a22b79ddfac67b8b4ab51b94ab68",
+    "content-hash": "e1ab31840c7db8f1728b13d29a396d38",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8370,6 +8370,179 @@
             "time": "2022-08-18T13:55:30+00:00"
         },
         {
+            "name": "google/apiclient",
+            "version": "v2.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-api-php-client.git",
+                "reference": "b1f63d72c44307ec8ef7bf18f1012de35d8944ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/b1f63d72c44307ec8ef7bf18f1012de35d8944ed",
+                "reference": "b1f63d72c44307ec8ef7bf18f1012de35d8944ed",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "^6.0",
+                "google/apiclient-services": "~0.350",
+                "google/auth": "^1.37",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.6",
+                "monolog/monolog": "^2.9||^3.0",
+                "php": "^8.0",
+                "phpseclib/phpseclib": "^3.0.36"
+            },
+            "require-dev": {
+                "cache/filesystem-adapter": "^1.1",
+                "composer/composer": "^1.10.23",
+                "phpcompatibility/php-compatibility": "^9.2",
+                "phpspec/prophecy-phpunit": "^2.1",
+                "phpunit/phpunit": "^9.6",
+                "squizlabs/php_codesniffer": "^3.8",
+                "symfony/css-selector": "~2.1",
+                "symfony/dom-crawler": "~2.1"
+            },
+            "suggest": {
+                "cache/filesystem-adapter": "For caching certs and tokens (using Google\\Client::setCache)"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/aliases.php"
+                ],
+                "psr-4": {
+                    "Google\\": "src/"
+                },
+                "classmap": [
+                    "src/aliases.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Client library for Google APIs",
+            "homepage": "http://developers.google.com/api-client-library/php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/google-api-php-client/issues",
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.17.0"
+            },
+            "time": "2024-07-10T14:57:54+00:00"
+        },
+        {
+            "name": "google/apiclient-services",
+            "version": "v0.370.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-api-php-client-services.git",
+                "reference": "25ad8515701dd832313d0f5f0a828670d60e541a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/25ad8515701dd832313d0f5f0a828670d60e541a",
+                "reference": "25ad8515701dd832313d0f5f0a828670d60e541a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "autoload.php"
+                ],
+                "psr-4": {
+                    "Google\\Service\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Client library for Google APIs",
+            "homepage": "http://developers.google.com/api-client-library/php",
+            "keywords": [
+                "google"
+            ],
+            "support": {
+                "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.370.0"
+            },
+            "time": "2024-08-26T01:04:18+00:00"
+        },
+        {
+            "name": "google/auth",
+            "version": "v1.42.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-auth-library-php.git",
+                "reference": "0c25599a91530b5847f129b271c536f75a7563f5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-auth-library-php/zipball/0c25599a91530b5847f129b271c536f75a7563f5",
+                "reference": "0c25599a91530b5847f129b271c536f75a7563f5",
+                "shasum": ""
+            },
+            "require": {
+                "firebase/php-jwt": "^6.0",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/psr7": "^2.4.5",
+                "php": "^8.0",
+                "psr/cache": "^2.0||^3.0",
+                "psr/http-message": "^1.1||^2.0"
+            },
+            "require-dev": {
+                "guzzlehttp/promises": "^2.0",
+                "kelvinmo/simplejwt": "0.7.1",
+                "phpseclib/phpseclib": "^3.0.35",
+                "phpspec/prophecy-phpunit": "^2.1",
+                "phpunit/phpunit": "^9.6",
+                "sebastian/comparator": ">=1.2.3",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^6.0||^7.0",
+                "webmozart/assert": "^1.11"
+            },
+            "suggest": {
+                "phpseclib/phpseclib": "May be used in place of OpenSSL for signing strings or for token management. Please require version ^2."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Google\\Auth\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Auth Library for PHP",
+            "homepage": "http://github.com/google/google-auth-library-php",
+            "keywords": [
+                "Authentication",
+                "google",
+                "oauth2"
+            ],
+            "support": {
+                "docs": "https://googleapis.github.io/google-auth-library-php/main/",
+                "issues": "https://github.com/googleapis/google-auth-library-php/issues",
+                "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.42.0"
+            },
+            "time": "2024-08-26T18:33:48+00:00"
+        },
+        {
             "name": "grasmash/expander",
             "version": "3.0.0",
             "source": {
@@ -10397,6 +10570,116 @@
                 "source": "https://github.com/phpowermove/docblock/tree/v4.0"
             },
             "time": "2021-09-22T16:57:06+00:00"
+        },
+        {
+            "name": "phpseclib/phpseclib",
+            "version": "3.0.41",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpseclib/phpseclib.git",
+                "reference": "621c73f7dcb310b61de34d1da4c4204e8ace6ceb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/621c73f7dcb310b61de34d1da4c4204e8ace6ceb",
+                "reference": "621c73f7dcb310b61de34d1da4c4204e8ace6ceb",
+                "shasum": ""
+            },
+            "require": {
+                "paragonie/constant_time_encoding": "^1|^2|^3",
+                "paragonie/random_compat": "^1.4|^2.0|^9.99.99",
+                "php": ">=5.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "suggest": {
+                "ext-dom": "Install the DOM extension to load XML formatted public keys.",
+                "ext-gmp": "Install the GMP (GNU Multiple Precision) extension in order to speed up arbitrary precision integer arithmetic operations.",
+                "ext-libsodium": "SSH2/SFTP can make use of some algorithms provided by the libsodium-php extension.",
+                "ext-mcrypt": "Install the Mcrypt extension in order to speed up a few other cryptographic operations.",
+                "ext-openssl": "Install the OpenSSL extension in order to speed up a wide variety of cryptographic operations."
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "phpseclib/bootstrap.php"
+                ],
+                "psr-4": {
+                    "phpseclib3\\": "phpseclib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jim Wigginton",
+                    "email": "terrafrost@php.net",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Patrick Monnerat",
+                    "email": "pm@datasphere.ch",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Andreas Fischer",
+                    "email": "bantu@phpbb.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Hans-Jürgen Petrich",
+                    "email": "petrich@tronic-media.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Graham Campbell",
+                    "email": "graham@alt-three.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP Secure Communications Library - Pure-PHP implementations of RSA, AES, SSH2, SFTP, X.509 etc.",
+            "homepage": "http://phpseclib.sourceforge.net",
+            "keywords": [
+                "BigInteger",
+                "aes",
+                "asn.1",
+                "asn1",
+                "blowfish",
+                "crypto",
+                "cryptography",
+                "encryption",
+                "rsa",
+                "security",
+                "sftp",
+                "signature",
+                "signing",
+                "ssh",
+                "twofish",
+                "x.509",
+                "x509"
+            ],
+            "support": {
+                "issues": "https://github.com/phpseclib/phpseclib/issues",
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.41"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/terrafrost",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpseclib",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpseclib/phpseclib",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-08-12T00:13:54+00:00"
         },
         {
             "name": "phrity/net-uri",

--- a/composer.lock
+++ b/composer.lock
@@ -13367,86 +13367,6 @@
             "time": "2024-05-31T15:07:36+00:00"
         },
         {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.30.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-05-31T15:07:36+00:00"
-        },
-        {
             "name": "symfony/polyfill-php81",
             "version": "v1.30.0",
             "source": {
@@ -14601,24 +14521,23 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.11.0",
+            "version": "v3.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "e80fb8ebba85c7341a97a9ebf825d7fd4b77708d"
+                "reference": "126b2c97818dbff0cdf3fbfc881aedb3d40aae72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/e80fb8ebba85c7341a97a9ebf825d7fd4b77708d",
-                "reference": "e80fb8ebba85c7341a97a9ebf825d7fd4b77708d",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/126b2c97818dbff0cdf3fbfc881aedb3d40aae72",
+                "reference": "126b2c97818dbff0cdf3fbfc881aedb3d40aae72",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5",
+                "php": ">=8.0.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-mbstring": "^1.3",
-                "symfony/polyfill-php80": "^1.22",
                 "symfony/polyfill-php81": "^1.29"
             },
             "require-dev": {
@@ -14665,7 +14584,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.11.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.14.0"
             },
             "funding": [
                 {
@@ -14677,7 +14596,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-08T16:15:16+00:00"
+            "time": "2024-09-09T17:55:12+00:00"
         },
         {
             "name": "twistor/flysystem-stream-wrapper",
@@ -19902,6 +19821,86 @@
                 }
             ],
             "time": "2024-01-23T14:51:35+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php80",
+            "version": "v1.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php80.git",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
+                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php80\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ion Bazan",
+                    "email": "ion.bazan@gmail.com"
+                },
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-31T15:07:36+00:00"
         },
         {
             "name": "symfony/polyfill-php82",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -38,7 +38,6 @@ module:
   flysystem: 0
   focal_point: 0
   gin_toolbar: 0
-  google_index_api: 0
   hdbt_admin_tools: 0
   health_check: 0
   helfi_api_base: 0

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -38,6 +38,7 @@ module:
   flysystem: 0
   focal_point: 0
   gin_toolbar: 0
+  google_index_api: 0
   hdbt_admin_tools: 0
   health_check: 0
   helfi_api_base: 0

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -46,6 +46,7 @@ module:
   helfi_ckeditor: 0
   helfi_etusivu_entities: 0
   helfi_eu_cookie_compliance: 0
+  helfi_google_api: 0
   helfi_hakuvahti: 0
   helfi_image_styles: 0
   helfi_media: 0

--- a/conf/cmi/helfi_google_api.settings.yml
+++ b/conf/cmi/helfi_google_api.settings.yml
@@ -1,1 +1,2 @@
+enabled: false
 indexing_api_key: ''

--- a/conf/cmi/helfi_google_api.settings.yml
+++ b/conf/cmi/helfi_google_api.settings.yml
@@ -1,2 +1,2 @@
-enabled: false
+dry_run: true
 indexing_api_key: ''

--- a/conf/cmi/helfi_google_api.settings.yml
+++ b/conf/cmi/helfi_google_api.settings.yml
@@ -1,0 +1,1 @@
+indexing_api_key: ''

--- a/public/modules/custom/helfi_google_api/README.md
+++ b/public/modules/custom/helfi_google_api/README.md
@@ -1,0 +1,47 @@
+# Google indexing api
+
+The module handles job listing indexing and deindexing using API provided by Google. Module requires an api key to work.
+Api key is only set to production environment since Google doesn't provide testing environment.
+
+* `drupal/scheduler` -module events are used to trigger the indexing requests.
+* `google/apiclient` -library is used to handle the communication with Google api.
+
+Api documentation: https://developers.google.com/search/apis/indexing-api/v3/quickstart
+Google library: https://github.com/googleapis/google-api-php-client
+Api key: Check keyvault
+
+## Development / local testing
+
+### API KEY
+You must set the api key in local.settings.php in order to use the module. Without it, the feature won't do anything at all.
+Api key is set to local.settings.php like this: `$config['helfi_google_api.settings']['indexing_api_key'] = '{}'`
+Instead of empty json object you can get the correct key from Keyvault.
+
+### Indexing requests
+
+The indexing api only allows sending urls pointing to hel.fi domain. Therefore you can properly test the features
+on production environment. You can send production urls to indexing api from local environment if you have
+the auth key set properly.
+
+Sending local url to google indexing api results in 4xx error.
+
+
+## Requests
+
+### Indexing
+
+* Indexing request is tied to scheduler event
+* A temporary redirect is created for the entity that is used for the indexing.
+
+### Deindexing
+
+* Dendexing request is tied to scheduler event
+* The temporary redirect is removed when deindexing is done.
+
+### Status check
+
+* You can send a status request to google api to find out if an URL has been indexed or deleted throuhg the API
+
+
+
+

--- a/public/modules/custom/helfi_google_api/README.md
+++ b/public/modules/custom/helfi_google_api/README.md
@@ -35,12 +35,12 @@ Sending local url to google indexing api results in 4xx error.
 
 ### Deindexing
 
-* Dendexing request is tied to scheduler event
+* Deindexing request is tied to scheduler event
 * The temporary redirect is removed when deindexing is done.
 
 ### Status check
 
-* You can send a status request to google api to find out if an URL has been indexed or deleted throuhg the API
+* You can send a status request to google api to find out if an URL has been indexed or deleted through the API
 
 
 

--- a/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
@@ -1,0 +1,7 @@
+name: 'Helfi Google api'
+type: module
+description: 'Google indexing api integration'
+package: HELfi
+core_version_requirement: ^10 || ^11
+dependencies:
+  - 'publication_date:publication_date'

--- a/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
@@ -6,3 +6,4 @@ core_version_requirement: ^10 || ^11
 dependencies:
   - 'publication_date:publication_date'
   - redirect:redirect
+  - scheduler:scheduler

--- a/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
@@ -7,4 +7,3 @@ dependencies:
   - 'publication_date:publication_date'
   - redirect:redirect
   - scheduler:scheduler
-  - helfi_api_base:helfi_api_base

--- a/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
@@ -5,3 +5,4 @@ package: HELfi
 core_version_requirement: ^10 || ^11
 dependencies:
   - 'publication_date:publication_date'
+  - redirect:redirect

--- a/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.info.yml
@@ -7,3 +7,4 @@ dependencies:
   - 'publication_date:publication_date'
   - redirect:redirect
   - scheduler:scheduler
+  - helfi_api_base:helfi_api_base

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -9,5 +9,10 @@ services:
 
   Drupal\helfi_google_api\HelfiGoogleApi: ~
 
-  Drupal\helfi_google_api\JobIndexingService: ~
+  Drupal\helfi_google_api\JobIndexingService:
+    class: Drupal\helfi_google_api\JobIndexingService
+    autowire: true
+    arguments:
+      $logger: '@logger.channel.helfi_google_api'
 
+  Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber: ~

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -9,11 +9,7 @@ services:
 
   Drupal\helfi_google_api\HelfiGoogleApi: ~
 
-  Drupal\helfi_google_api\JobIndexingService:
-    class: Drupal\helfi_google_api\JobIndexingService
-    autowire: true
-    arguments:
-      $logger: '@logger.channel.helfi_google_api'
+  Drupal\helfi_google_api\JobIndexingService: ~
 
   Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber:
     class: Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -15,4 +15,8 @@ services:
     arguments:
       $logger: '@logger.channel.helfi_google_api'
 
-  Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber: ~
+  Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber:
+    class: Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber
+    autowire: true
+    arguments:
+      $logger: '@logger.channel.helfi_google_api'

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -9,10 +9,10 @@ services:
 
   Drupal\helfi_google_api\HelfiGoogleApi: ~
 
-  Drupal\helfi_google_api\JobIndexingService: ~
-
-  Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber:
-    class: Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber
+  Drupal\helfi_google_api\JobIndexingService:
+    class: Drupal\helfi_google_api\JobIndexingService
     autowire: true
     arguments:
       $logger: '@logger.channel.helfi_google_api'
+
+  Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber: ~

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -1,0 +1,13 @@
+services:
+  _defaults:
+    autoconfigure: true
+    autowire: true
+
+  logger.channel.helfi_google_api:
+    parent: logger.channel_base
+    arguments: ['helfi_google_api']
+
+  Drupal\helfi_google_api\HelfiGoogleApi: ~
+
+  Drupal\helfi_google_api\JobIndexingService: ~
+

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -7,7 +7,11 @@ services:
     parent: logger.channel_base
     arguments: ['helfi_google_api']
 
-  Drupal\helfi_google_api\GoogleApi: ~
+  Drupal\helfi_google_api\GoogleApi:
+    class: Drupal\helfi_google_api\GoogleApi
+    arguments:
+      - '@config.factory'
+      - '@helfi_google_api.google_service'
 
   Drupal\helfi_google_api\JobIndexingService:
     class: Drupal\helfi_google_api\JobIndexingService
@@ -16,3 +20,15 @@ services:
       $logger: '@logger.channel.helfi_google_api'
 
   Drupal\helfi_google_api\EventSubscriber\JobPublishStateSubscriber: ~
+
+  helfi_google_api.google_service:
+    public: false
+    class: \Google\Service\Indexing
+    factory: [ '@helfi_google_api.google_service_factory', 'create']
+    arguments:
+      - '@config.factory'
+
+  helfi_google_api.google_service_factory:
+    class: Drupal\helfi_google_api\GoogleServiceFactory
+    arguments:
+      - '@config.factory'

--- a/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
+++ b/public/modules/custom/helfi_google_api/helfi_google_api.services.yml
@@ -7,7 +7,7 @@ services:
     parent: logger.channel_base
     arguments: ['helfi_google_api']
 
-  Drupal\helfi_google_api\HelfiGoogleApi: ~
+  Drupal\helfi_google_api\GoogleApi: ~
 
   Drupal\helfi_google_api\JobIndexingService:
     class: Drupal\helfi_google_api\JobIndexingService

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/GoogleIndexingApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/GoogleIndexingApiCommands.php
@@ -19,7 +19,7 @@ use Drush\Commands\DrushCommands;
 /**
  * A Drush command file.
  */
-final class HelfiApiCommands extends DrushCommands {
+final class GoogleIndexingApiCommands extends DrushCommands {
 
   use AutowireTrait;
 

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/GoogleIndexingApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/GoogleIndexingApiCommands.php
@@ -189,7 +189,7 @@ final class GoogleIndexingApiCommands extends DrushCommands {
       return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
     }
 
-    if ($response->isDebug()) {
+    if ($response->isDryRun()) {
       $urls = $response->getUrls();
       $this->io()->writeln('The api request would have sent following data: ' . json_encode($urls));
       return DrushCommands::EXIT_SUCCESS;

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -134,7 +134,7 @@ final class HelfiApiCommands extends DrushCommands {
    *   The exit code.
    */
   #[Command(name: 'helfi:google-url-index-status')]
-  public function checkUrlIndexStatus(string $url) {
+  public function checkUrlIndexStatus(string $url): int {
     try {
       $response = $this->jobIndexingService->checkItemIndexStatus($url);
     }
@@ -159,7 +159,7 @@ final class HelfiApiCommands extends DrushCommands {
    *   The exit code.
    */
   #[Command(name: 'helfi:google-entity-index-status')]
-  public function checkEntityIndexStatus(int $entity_id, $langcode = 'fi') {
+  public function checkEntityIndexStatus(int $entity_id, $langcode = 'fi'): int {
     $entity = Node::load($entity_id);
 
     if (!$entity instanceof JobListing) {

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -14,6 +14,7 @@ use Drupal\path_alias\AliasManagerInterface;
 use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
+use Drupal\helfi_google_api\Response;
 
 /**
  * A Drush command file.
@@ -69,19 +70,7 @@ final class HelfiApiCommands extends DrushCommands {
       return DrushCommands::EXIT_FAILURE;
     }
 
-    if ($response->getErrors()) {
-      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response->getErrors()));
-      return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
-    }
-
-    if ($response->isDebug()) {
-      $urls = $response->getUrls();
-      $this->io()->writeln('The api request would have sent following data: ' . json_encode($urls));
-      return DrushCommands::EXIT_SUCCESS;
-    }
-
-    $this->io()->writeln('Url indexed succesfully.');
-    return DrushCommands::EXIT_SUCCESS;
+    return $this->handleResponse($response);
   }
 
   /**
@@ -121,19 +110,7 @@ final class HelfiApiCommands extends DrushCommands {
       return DrushCommands::EXIT_FAILURE;
     }
 
-    if ($response->getErrors()) {
-      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response->getErrors()));
-      return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
-    }
-
-    if ($response->isDebug()) {
-      $urls = $response->getUrls();
-      $this->io()->writeln('The api request would have sent following data: ' . json_encode($urls));
-      return DrushCommands::EXIT_SUCCESS;
-    }
-
-    $this->io()->writeln('Url deindexed succesfully.');
-    return DrushCommands::EXIT_SUCCESS;
+    return $this->handleResponse($response);
   }
 
   /**
@@ -194,6 +171,31 @@ final class HelfiApiCommands extends DrushCommands {
     }
 
     $this->io()->writeln($response);
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+  /**
+   * Handle response.
+   *
+   * @param Drupal\helfi_google_api\Response $response
+   *   The response object.
+   *
+   * @return int
+   *   Exit code.
+   */
+  private function handleResponse(Response $response): int {
+    if ($response->getErrors()) {
+      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response->getErrors()));
+      return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
+    }
+
+    if ($response->isDebug()) {
+      $urls = $response->getUrls();
+      $this->io()->writeln('The api request would have sent following data: ' . json_encode($urls));
+      return DrushCommands::EXIT_SUCCESS;
+    }
+
+    $this->io()->writeln('Url indexed succesfully.');
     return DrushCommands::EXIT_SUCCESS;
   }
 

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -78,6 +78,17 @@ final class HelfiApiCommands extends DrushCommands {
     return DrushCommands::EXIT_SUCCESS;
   }
 
+  /**
+   * Deindex single entity by id,
+   *
+   * @param int $entity_id
+   *   The entity id.
+   * @param string $langcode
+   *   The entity langcode.
+   *
+   * @return int
+   *   The exit code.
+   */
   #[Command(name: 'helfi:google-single-entity-deindex')]
   public function deindexSingleItem(
     int $entity_id,

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -11,11 +11,9 @@ use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\node\Entity\Node;
 use Drupal\path_alias\AliasManagerInterface;
-use Drupal\redirect\Entity\Redirect;
 use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * A Drush command file.
@@ -45,7 +43,7 @@ final class HelfiApiCommands extends DrushCommands {
    * @return int
    *   The exit code.
    */
-  #[Command(name: 'helfi:single-index-google')]
+  #[Command(name: 'helfi:google-single-entity-index')]
   public function indexSingleItem(
     int $entity_id,
     string $langcode = 'fi',

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_google_api\Drush\Commands;
+
+use Drupal\helfi_google_api\JobIndexingService;
+use Drush\Attributes\Command;
+use Drush\Commands\AutowireTrait;
+use Drush\Commands\DrushCommands;
+
+/**
+ * A Drush command file.
+ */
+final class HelfiApiCommands extends DrushCommands {
+
+  use AutowireTrait;
+
+  public function __construct(
+    private readonly JobIndexingService $jobIndexingService,
+  ) {
+    parent::__construct();
+  }
+
+  #[Command(name: 'helfi:index-google')]
+  public function process() : int {
+    $this->jobIndexingService->indexUpdatedJobs();
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+}

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -79,7 +79,7 @@ final class HelfiApiCommands extends DrushCommands {
   }
 
   /**
-   * Deindex single entity by id,
+   * Deindex single entity by id.
    *
    * @param int $entity_id
    *   The entity id.

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_google_api\Drush\Commands;
 
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\node\Entity\Node;
+use Drupal\path_alias\AliasManagerInterface;
 use Drupal\redirect\Entity\Redirect;
 use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * A Drush command file.
@@ -21,108 +26,114 @@ final class HelfiApiCommands extends DrushCommands {
 
   public function __construct(
     private readonly JobIndexingService $jobIndexingService,
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly LanguageManagerInterface $languageManager,
+    private readonly AliasManagerInterface $aliasManager,
+    private readonly UrlGeneratorInterface $urlGenerator,
   ) {
     parent::__construct();
   }
 
+  /**
+   * Index single job listing.
+   *
+   * @param int $entity_id
+   *   The entity id.
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return int
+   *   The exit code.
+   */
   #[Command(name: 'helfi:single-index-google')]
   public function indexSingleItem(
     int $entity_id,
     string $langcode = 'fi',
   ) : int {
-    $job = Node::load($entity_id);
-    if (!$job instanceof JobListing) {
+    $entity = Node::load($entity_id);
+
+    if (!$entity instanceof JobListing) {
       $this->io()->writeln('Entity not found or not instance of JobListing');
       return DrushCommands::EXIT_FAILURE;
     }
 
-    $job_alias = \Drupal::service('path_alias.manager')->getAliasByPath("/node/{$job->id()}", $langcode);
-
-    // Check if entity has already been indexed.
-    $redirectIds = \Drupal::entityQuery('redirect')
-      ->condition('redirect_redirect__uri', "internal:/node/{$job->id()}")
-      ->condition('status_code', 301)
-      ->condition('language', $langcode)
-      ->accessCheck(FALSE)
-      ->execute();
-
-    $redirects = Redirect::loadMultiple($redirectIds);
-
-    foreach ($redirects as $redirect) {
-      $source = $redirect->getSourceUrl();
-
-      if (str_contains($source, "$job_alias-")) {
-        $this->io()->writeln('Entity has temporary redirect which indicates
-          that indexing has already been requested.');
-        return DrushCommands::EXIT_FAILURE;
-      }
+    if (!$entity->hasTranslation($langcode)) {
+      $this->io()->writeln('Translation does not exist.');
+      return DrushCommands::EXIT_FAILURE;
     }
-
-    $now = strtotime('now');
-    $temp_alias = "$job_alias-$now";
-    $indexing_url = "{$job->toUrl()->setAbsolute()->toString()}-$now";
-
-    $redirect = Redirect::create([
-      'redirect_source' => ltrim($temp_alias, '/'),
-      'redirect_redirect' => "internal:/node/{$job->id()}",
-      'language' => $langcode,
-      'status_code' => 301,
-    ]);
+    $entity = $entity->getTranslation($langcode);
 
     try {
-      $redirect->save();
+      $response = $this->jobIndexingService->indexEntity($entity);
     }
     catch (\Exception $e) {
-      $this->io()->writeln('Failed to create temporary redirect for the entity.');
+      $this->io()->error($e->getMessage());
       return DrushCommands::EXIT_FAILURE;
     }
 
-    $this->jobIndexingService->indexItem($indexing_url);
+    if ($response['errors']) {
+      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response['errors']));
+      return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
+    }
+
+    $this->io()->writeln('Url indexed succesfully.');
     return DrushCommands::EXIT_SUCCESS;
   }
 
-  #[Command(name: 'helfi:google-index-status-check')]
-  public function checkItemIndexStatus(int $entity_id, $langcode = 'fi') {
-    $job = Node::load($entity_id);
-    if (!$job instanceof JobListing) {
+  /**
+   * Request url indexing status from Google api.
+   *
+   * @param int $url
+   *   The url to check.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:google-url-index-status')]
+  public function checkUrlIndexStatus(string $url) {
+    try {
+      $response = $this->jobIndexingService->checkItemIndexStatus($url);
+    }
+    catch (\Exception $e) {
+      $this->io()->writeln($e->getMessage());
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $this->io()->writeln($response);
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+  /**
+   * Check entity indexing status.
+   *
+   * @param int $entity_id
+   *   The entity id.
+   * @param string $langcode
+   *   The language code.
+   *
+   * @return int
+   *   The exit code.
+   */
+  #[Command(name: 'helfi:google-entity-index-status')]
+  public function checkEntityIndexStatus(int $entity_id, $langcode = 'fi') {
+    $entity = Node::load($entity_id);
+
+    if (!$entity instanceof JobListing) {
       $this->io()->writeln('Entity not found or not instance of JobListing');
       return DrushCommands::EXIT_FAILURE;
     }
 
-    $language = \Drupal::languageManager()->getLanguage($langcode);
-    $baseUrl = \Drupal::urlGenerator()->generateFromRoute('<front>', [], ['absolute' => TRUE, 'language' => $language]);
-    $job_alias = \Drupal::service('path_alias.manager')->getAliasByPath("/node/{$job->id()}", $langcode);
-
-    // Check if entity has already been indexed.
-    $redirectIds = \Drupal::entityQuery('redirect')
-      ->condition('redirect_redirect__uri', "internal:/node/{$job->id()}")
-      ->condition('status_code', 301)
-      ->condition('language', $langcode)
-      ->accessCheck(FALSE)
-      ->execute();
-
-    // Get the indexed redirect.
-    $redirects = Redirect::loadMultiple($redirectIds);
-    foreach ($redirects as $redirect) {
-      $source = $redirect->getSourceUrl();
-
-      if (str_contains($source, "$job_alias-")) {
-        $correct_redirect = $redirect;
-        break;
-      }
-    }
-
-    if (!$correct_redirect) {
-      $this->io()->writeln('Redirect request has not been sent.');
+    if (!$entity->hasTranslation($langcode)) {
+      $this->io()->writeln('Translation does not exist.');
       return DrushCommands::EXIT_FAILURE;
     }
+    $entity = $entity->getTranslation($langcode);
 
-    $url_to_check = $baseUrl . $redirect->getSourceUrl();
     try {
-      $response = $this->jobIndexingService->checkItemIndexStatus($url_to_check);
+      $response = $this->jobIndexingService->checkEntityIndexStatus($entity);
     }
     catch (\Exception $e) {
-      $this->io()->writeln('Something went wrong: ' . $e->getMessage());
+      $this->io()->writeln($e->getMessage());
       return DrushCommands::EXIT_FAILURE;
     }
 

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Drupal\helfi_google_api\Drush\Commands;
 
 use Drupal\helfi_google_api\JobIndexingService;
+use Drupal\helfi_rekry_content\Entity\JobListing;
+use Drupal\node\Entity\Node;
+use Drupal\redirect\Entity\Redirect;
 use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
@@ -22,9 +25,108 @@ final class HelfiApiCommands extends DrushCommands {
     parent::__construct();
   }
 
-  #[Command(name: 'helfi:index-google')]
-  public function process() : int {
-    $this->jobIndexingService->indexUpdatedJobs();
+  #[Command(name: 'helfi:single-index-google')]
+  public function indexSingleItem(
+    int $entity_id,
+    string $langcode = 'fi',
+  ) : int {
+    $job = Node::load($entity_id);
+    if (!$job instanceof JobListing) {
+      $this->io()->writeln('Entity not found or not instance of JobListing');
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $job_alias = \Drupal::service('path_alias.manager')->getAliasByPath("/node/{$job->id()}", $langcode);
+
+    // Check if entity has already been indexed.
+    $redirectIds = \Drupal::entityQuery('redirect')
+      ->condition('redirect_redirect__uri', "internal:/node/{$job->id()}")
+      ->condition('status_code', 301)
+      ->condition('language', $langcode)
+      ->accessCheck(FALSE)
+      ->execute();
+
+    $redirects = Redirect::loadMultiple($redirectIds);
+
+    foreach ($redirects as $redirect) {
+      $source = $redirect->getSourceUrl();
+
+      if (str_contains($source, "$job_alias-")) {
+        $this->io()->writeln('Entity has temporary redirect which indicates
+          that indexing has already been requested.');
+        return DrushCommands::EXIT_FAILURE;
+      }
+    }
+
+    $now = strtotime('now');
+    $temp_alias = "$job_alias-$now";
+    $indexing_url = "{$job->toUrl()->setAbsolute()->toString()}-$now";
+
+    $redirect = Redirect::create([
+      'redirect_source' => ltrim($temp_alias, '/'),
+      'redirect_redirect' => "internal:/node/{$job->id()}",
+      'language' => $langcode,
+      'status_code' => 301,
+    ]);
+
+    try {
+      $redirect->save();
+    }
+    catch (\Exception $e) {
+      $this->io()->writeln('Failed to create temporary redirect for the entity.');
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $this->jobIndexingService->indexItem($indexing_url);
+    return DrushCommands::EXIT_SUCCESS;
+  }
+
+  #[Command(name: 'helfi:google-index-status-check')]
+  public function checkItemIndexStatus(int $entity_id, $langcode = 'fi') {
+    $job = Node::load($entity_id);
+    if (!$job instanceof JobListing) {
+      $this->io()->writeln('Entity not found or not instance of JobListing');
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $language = \Drupal::languageManager()->getLanguage($langcode);
+    $baseUrl = \Drupal::urlGenerator()->generateFromRoute('<front>', [], ['absolute' => TRUE, 'language' => $language]);
+    $job_alias = \Drupal::service('path_alias.manager')->getAliasByPath("/node/{$job->id()}", $langcode);
+
+    // Check if entity has already been indexed.
+    $redirectIds = \Drupal::entityQuery('redirect')
+      ->condition('redirect_redirect__uri', "internal:/node/{$job->id()}")
+      ->condition('status_code', 301)
+      ->condition('language', $langcode)
+      ->accessCheck(FALSE)
+      ->execute();
+
+    // Get the indexed redirect.
+    $redirects = Redirect::loadMultiple($redirectIds);
+    foreach ($redirects as $redirect) {
+      $source = $redirect->getSourceUrl();
+
+      if (str_contains($source, "$job_alias-")) {
+        $correct_redirect = $redirect;
+        break;
+      }
+    }
+
+    if (!$correct_redirect) {
+      $this->io()->writeln('Redirect request has not been sent.');
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $url_to_check = $baseUrl . $redirect->getSourceUrl();
+    try {
+      $response = $this->jobIndexingService->checkItemIndexStatus($url_to_check);
+    }
+    catch (\Exception $e) {
+      $this->io()->writeln('Something went wrong: ' . $e->getMessage());
+      return DrushCommands::EXIT_FAILURE;
+    }
+
+    $this->io()->writeln($response);
     return DrushCommands::EXIT_SUCCESS;
   }
 

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -127,7 +127,7 @@ final class HelfiApiCommands extends DrushCommands {
   /**
    * Request url indexing status from Google api.
    *
-   * @param int $url
+   * @param string $url
    *   The url to check.
    *
    * @return int

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -8,13 +8,13 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\helfi_google_api\JobIndexingService;
+use Drupal\helfi_google_api\Response;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\node\Entity\Node;
 use Drupal\path_alias\AliasManagerInterface;
 use Drush\Attributes\Command;
 use Drush\Commands\AutowireTrait;
 use Drush\Commands\DrushCommands;
-use Drupal\helfi_google_api\Response;
 
 /**
  * A Drush command file.
@@ -177,7 +177,7 @@ final class HelfiApiCommands extends DrushCommands {
   /**
    * Handle response.
    *
-   * @param Drupal\helfi_google_api\Response $response
+   * @param \Drupal\helfi_google_api\Response $response
    *   The response object.
    *
    * @return int

--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/HelfiApiCommands.php
@@ -69,9 +69,15 @@ final class HelfiApiCommands extends DrushCommands {
       return DrushCommands::EXIT_FAILURE;
     }
 
-    if ($response['errors']) {
-      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response['errors']));
+    if ($response->getErrors()) {
+      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response->getErrors()));
       return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
+    }
+
+    if ($response->isDebug()) {
+      $urls = $response->getUrls();
+      $this->io()->writeln('The api request would have sent following data: ' . json_encode($urls));
+      return DrushCommands::EXIT_SUCCESS;
     }
 
     $this->io()->writeln('Url indexed succesfully.');
@@ -115,9 +121,15 @@ final class HelfiApiCommands extends DrushCommands {
       return DrushCommands::EXIT_FAILURE;
     }
 
-    if ($response['errors']) {
-      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response['errors']));
+    if ($response->getErrors()) {
+      $this->io()->writeln('Request successful. Errors returned: ' . json_encode($response->getErrors()));
       return DrushCommands::EXIT_FAILURE_WITH_CLARITY;
+    }
+
+    if ($response->isDebug()) {
+      $urls = $response->getUrls();
+      $this->io()->writeln('The api request would have sent following data: ' . json_encode($urls));
+      return DrushCommands::EXIT_SUCCESS;
     }
 
     $this->io()->writeln('Url deindexed succesfully.');

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -6,10 +6,8 @@ namespace Drupal\helfi_google_api\EventSubscriber;
 
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
-use Drupal\redirect\Entity\Redirect;
 use Drupal\scheduler\SchedulerEvent;
 use Drupal\scheduler\SchedulerEvents;
-use Drush\Commands\DrushCommands;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -19,6 +17,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
 
   public function __construct(
     private readonly JobIndexingService $jobIndexingService,
+    private readonly LoggerInterface $logger,
   ) {
   }
 
@@ -91,7 +90,6 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
 
     $redirect = $this->jobIndexingService->getExistingTemporaryRedirect($entity, $langcode);
     if (!$redirect) {
-      // Log, the item seems not to be indexed.
       return;
     }
 

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -21,6 +21,8 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\helfi_google_api\JobIndexingService $jobIndexingService
    *   The job indexing service.
+   * @param Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $environmentResolver
+   *   The environment resolver.
    */
   public function __construct(
     private readonly JobIndexingService $jobIndexingService,

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -11,7 +11,7 @@ use Drupal\scheduler\SchedulerEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * Subscribe to job publishing events
+ * Subscribe to job publishing events.
  */
 class JobPublishStateSubscriber implements EventSubscriberInterface {
 
@@ -35,8 +35,6 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
       SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',
       SchedulerEvents::UNPUBLISH => 'sendDeindexingRequest',
     ];
-
-    return [];
   }
 
   /**

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -21,7 +21,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\helfi_google_api\JobIndexingService $jobIndexingService
    *   The job indexing service.
-   * @param Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $environmentResolver
+   * @param \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $environmentResolver
    *   The environment resolver.
    */
   public function __construct(

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -30,12 +30,15 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
-    // @todo Enable when tested with cron commands.
+    // @todo Enable after feature tested in production.
+    /*
     return [
-      SchedulerEvents::PUBLISH => 'sendIndexingRequest',
-      SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',
-      SchedulerEvents::UNPUBLISH => 'sendDeindexingRequest',
+    SchedulerEvents::PUBLISH => 'sendIndexingRequest',
+    SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',
+    SchedulerEvents::UNPUBLISH => 'sendDeindexingRequest',
     ];
+     */
+    return [];
   }
 
   /**

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_google_api\EventSubscriber;
+
+use Drupal\elasticsearch_connector\Event\PrepareIndexEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * {@inheritdoc}
+ */
+class JobPublishSubscriber implements EventSubscriberInterface {
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    return [
+      PrepareIndexEvent::PREPARE_INDEX => 'prepareIndices',
+    ];
+  }
+
+  /**
+   * Method to prepare index.
+   *
+   * @param \Drupal\elasticsearch_connector\Event\PrepareIndexEvent $event
+   *   The PrepareIndex event.
+   */
+  public function prepareIndices(PrepareIndexEvent $event) {
+    $indexName = $event->getIndexName();
+    $finnishIndices = [
+      'job_listings',
+    ];
+    if (in_array($indexName, $finnishIndices)) {
+      /** @var array $indexConfig */
+      $indexConfig = $event->getIndexConfig();
+      $indexConfig['body']['settings']['analysis']['analyzer']['default']['type'] = 'finnish';
+      $event->setIndexConfig($indexConfig);
+    }
+  }
+
+}

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -53,8 +53,8 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
     try {
       $this->jobIndexingService->indexEntity($entity);
     }
-    catch(\Exception $exception){
-      // has been logged by indexing service.
+    catch (\Exception $exception) {
+      // Has been logged by indexing service.
     }
   }
 
@@ -73,7 +73,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
     try {
       $this->jobIndexingService->deindexEntity($entity);
     }
-    catch(\Exception) {
+    catch (\Exception) {
       // Has been logged by indexing service.
     }
   }

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_google_api\EventSubscriber;
 
-use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\scheduler\SchedulerEvent;
@@ -16,10 +15,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class JobPublishStateSubscriber implements EventSubscriberInterface {
 
+  /**
+   * The constructor.
+   *
+   * @param \Drupal\helfi_google_api\JobIndexingService $jobIndexingService
+   *   The job indexing service.
+   */
   public function __construct(
     private readonly JobIndexingService $jobIndexingService,
-    private readonly LoggerInterface $logger,
-    private readonly UrlGeneratorInterface $urlGenerator,
   ) {
   }
 

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -7,6 +7,7 @@ namespace Drupal\helfi_google_api\EventSubscriber;
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\scheduler\SchedulerEvent;
+use Drupal\scheduler\SchedulerEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
@@ -29,14 +30,12 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
-    // @todo Enable after feature tested in production.
-    /*
     return [
-    SchedulerEvents::PUBLISH => 'sendIndexingRequest',
-    SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',
-    SchedulerEvents::UNPUBLISH => 'sendDeindexingRequest',
+      SchedulerEvents::PUBLISH => 'sendIndexingRequest',
+      SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',
+      SchedulerEvents::UNPUBLISH => 'sendDeindexingRequest',
     ];
-     */
+
     return [];
   }
 

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -30,6 +30,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    * {@inheritdoc}
    */
   public static function getSubscribedEvents(): array {
+    // @todo Enable when tested with cron commands.
     return [
       SchedulerEvents::PUBLISH => 'sendIndexingRequest',
       SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',
@@ -49,7 +50,12 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $this->jobIndexingService->indexEntity($entity);
+    try {
+      $this->jobIndexingService->indexEntity($entity);
+    }
+    catch(\Exception $exception){
+      // has been logged by indexing service.
+    }
   }
 
   /**
@@ -64,7 +70,12 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $this->jobIndexingService->deindexEntity($entity);
+    try {
+      $this->jobIndexingService->deindexEntity($entity);
+    }
+    catch(\Exception) {
+      // Has been logged by indexing service.
+    }
   }
 
 }

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -7,7 +7,6 @@ namespace Drupal\helfi_google_api\EventSubscriber;
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\scheduler\SchedulerEvent;
-use Drupal\scheduler\SchedulerEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_google_api\EventSubscriber;
 
+use Drupal\Core\Routing\UrlGeneratorInterface;
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\scheduler\SchedulerEvent;
@@ -18,6 +19,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
   public function __construct(
     private readonly JobIndexingService $jobIndexingService,
     private readonly LoggerInterface $logger,
+    private readonly UrlGeneratorInterface $urlGenerator,
   ) {
   }
 
@@ -79,7 +81,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    * Send deindexing request to google.
    *
    * @param SchedulerEvent $event
-   * @return void
+   *   The scheduler event.
    */
   public function sendDeindexingRequest(SchedulerEvent $event) {
     $entity = $event->getNode();
@@ -93,7 +95,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
       return;
     }
 
-    $base_url = \Drupal::urlGenerator()->generateFromRoute(
+    $base_url = $this->urlGenerator->generateFromRoute(
       '<front>',
       [],
       ['absolute' => TRUE,'language' => $entity->language()]

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_google_api\EventSubscriber;
 
-use Drupal\helfi_api_base\Environment\EnvironmentEnum;
-use Drupal\helfi_api_base\Environment\EnvironmentResolverInterface;
 use Drupal\helfi_google_api\JobIndexingService;
 use Drupal\helfi_rekry_content\Entity\JobListing;
 use Drupal\scheduler\SchedulerEvent;
@@ -21,12 +19,9 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    *
    * @param \Drupal\helfi_google_api\JobIndexingService $jobIndexingService
    *   The job indexing service.
-   * @param \Drupal\helfi_api_base\Environment\EnvironmentResolverInterface $environmentResolver
-   *   The environment resolver.
    */
   public function __construct(
     private readonly JobIndexingService $jobIndexingService,
-    private readonly EnvironmentResolverInterface $environmentResolver,
   ) {
   }
 
@@ -52,10 +47,6 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    *   The scheduler event.
    */
   public function sendIndexingRequest(SchedulerEvent $event): void {
-    if (!$this->isProduction()) {
-      return;
-    }
-
     $entity = $event->getNode();
     if (!$entity instanceof JobListing) {
       return;
@@ -76,10 +67,6 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
    *   The scheduler event.
    */
   public function sendDeindexingRequest(SchedulerEvent $event): void {
-    if (!$this->isProduction()) {
-      return;
-    }
-
     $entity = $event->getNode();
     if (!$entity instanceof JobListing) {
       return;
@@ -91,16 +78,6 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
     catch (\Exception) {
       // Has been logged by indexing service.
     }
-  }
-
-  /**
-   * Check if in production.
-   *
-   * @return bool
-   *   Is production.
-   */
-  private function isProduction(): bool {
-    return $this->environmentResolver->getActiveEnvironment()->getEnvironment() === EnvironmentEnum::Prod;
   }
 
 }

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -29,7 +29,7 @@ class JobPublishStateSubscriber implements EventSubscriberInterface {
   /**
    * {@inheritdoc}
    */
-  public static function getSubscribedEvents() {
+  public static function getSubscribedEvents(): array {
     return [
       SchedulerEvents::PUBLISH => 'sendIndexingRequest',
       SchedulerEvents::PUBLISH_IMMEDIATELY => 'sendIndexRequest',

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobPublishStateSubscriber.php
@@ -11,7 +11,7 @@ use Drupal\scheduler\SchedulerEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 /**
- * {@inheritdoc}
+ * Subscribe to job publishing events
  */
 class JobPublishStateSubscriber implements EventSubscriberInterface {
 

--- a/public/modules/custom/helfi_google_api/src/GoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleApi.php
@@ -57,9 +57,9 @@ class GoogleApi {
   public function isDryRun(): bool {
     $config = $this->configFactory->get('helfi_google_api.settings');
     $key = $config->get('indexing_api_key') ?: '';
-    $isEnabled = $config->get('enabled') ?: FALSE;
+    $dryRun = $config->get('dry_run') ?: TRUE;
 
-    return !$key && !$isEnabled;
+    return !$key || $dryRun;
   }
 
   /**

--- a/public/modules/custom/helfi_google_api/src/GoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleApi.php
@@ -47,7 +47,7 @@ class GoogleApi {
     private readonly Indexing $indexingService,
   ) {
   }
-  
+
   /**
    * Correct environment and key is set.
    *
@@ -113,6 +113,7 @@ class GoogleApi {
    * Request url indexing status.
    *
    * Returns the dates of last update and delete requests.
+   * For debugging purposes only, since it spends the quota.
    *
    * @param string $url
    *   The url which indexing status you want to request.
@@ -125,8 +126,10 @@ class GoogleApi {
     $client->setUseBatch(FALSE);
 
     if ($this->isDryRun()) {
-      $client = $client->authorize();
+      return "Dry running index status query with url: $url";
     }
+
+    $client = $client->authorize();
 
     $baseUrl = self::METADATA_ENDPOINT;
     $query_parameter = '?url=' . urlencode($url);

--- a/public/modules/custom/helfi_google_api/src/GoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleApi.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Psr7\Request;
 /**
  * A wrapper for Google indexing library.
  */
-class HelfiGoogleApi {
+class GoogleApi {
 
   /**
    * Endpoint for sending update and delete requests.
@@ -129,13 +129,13 @@ class HelfiGoogleApi {
   public function checkIndexingStatus(string $url): string {
     $this->initializeApi(FALSE);
 
-    $base_url = self::METADATA_ENDPOINT;
-    $queryParameter = '?url=' . urlencode($url);
-    $the_url = $base_url . $queryParameter;
+    $baseUrl = self::METADATA_ENDPOINT;
+    $query_parameter = '?url=' . urlencode($url);
+    $theUrl = $baseUrl . $query_parameter;
 
     $client = $this->indexingService->getClient()->authorize();
 
-    $response = $client->request('GET', $the_url);
+    $response = $client->request('GET', $theUrl);
 
     return $response->getBody()->getContents();
   }

--- a/public/modules/custom/helfi_google_api/src/GoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleApi.php
@@ -49,7 +49,7 @@ class GoogleApi {
   }
 
   /**
-   * Correct environment and key is set.
+   * Correct environment and key is set and enabled is true.
    *
    * @return bool
    *   The api is set up
@@ -59,7 +59,7 @@ class GoogleApi {
     $key = $config->get('indexing_api_key') ?: '';
     $isEnabled = $config->get('enabled') ?: FALSE;
 
-    return $key && $isEnabled;
+    return !$key && !$isEnabled;
   }
 
   /**
@@ -74,8 +74,8 @@ class GoogleApi {
    *   Object which holds the handled urls and request errors.
    */
   public function indexBatch(array $urls, bool $update): Response {
-    if (!$this->isDryRun()) {
-      return new Response($urls, debug: TRUE);
+    if ($this->isDryRun()) {
+      return new Response($urls, dryRun: TRUE);
     }
 
     $batch = $this->indexingService->createBatch();

--- a/public/modules/custom/helfi_google_api/src/GoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleApi.php
@@ -47,19 +47,7 @@ class GoogleApi {
     private readonly Indexing $indexingService,
   ) {
   }
-
-  /**
-   * Does the api key exist.
-   *
-   * @return bool
-   *   Api key exists.
-   */
-  public function hasAuthenticationKey(): bool {
-    $config = $this->configFactory->get('helfi_google_api.settings');
-    $key = $config->get('indexing_api_key') ?: '';
-    return (bool) $key;
-  }
-
+  
   /**
    * Correct environment and key is set.
    *

--- a/public/modules/custom/helfi_google_api/src/GoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleApi.php
@@ -66,7 +66,7 @@ class GoogleApi {
    * @return bool
    *   The api is set up
    */
-  public function isEnabled(): bool {
+  public function isDryRun(): bool {
     $config = $this->configFactory->get('helfi_google_api.settings');
     $key = $config->get('indexing_api_key') ?: '';
     $isEnabled = $config->get('enabled') ?: FALSE;
@@ -86,7 +86,7 @@ class GoogleApi {
    *   Object which holds the handled urls and request errors.
    */
   public function indexBatch(array $urls, bool $update): Response {
-    if (!$this->isEnabled()) {
+    if (!$this->isDryRun()) {
       return new Response($urls, debug: TRUE);
     }
 
@@ -136,7 +136,7 @@ class GoogleApi {
     $client = $this->indexingService->getClient();
     $client->setUseBatch(FALSE);
 
-    if ($this->isEnabled()) {
+    if ($this->isDryRun()) {
       $client = $client->authorize();
     }
 

--- a/public/modules/custom/helfi_google_api/src/GoogleServiceFactory.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleServiceFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_google_api;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Google\Client as GoogleClient;
+use Google\Service\Indexing;
+
+/**
+ * Create and set up Google service and client.
+ */
+class GoogleServiceFactory {
+
+  /**
+   * Api scopes.
+   */
+  const SCOPES = ['https://www.googleapis.com/auth/indexing'];
+
+  /**
+   * Google service factory method.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   *
+   * @return \Google\Service\Indexing
+   *   Google indexing service.
+   */
+  public function create(ConfigFactoryInterface $configFactory): Indexing {
+    $config = $configFactory->get('helfi_google_api.settings');
+    $key = $config->get('indexing_api_key') ?: '';
+
+    $client = new GoogleClient();
+    $client->setApplicationName('Helfi_Rekry');
+    $client->addScope(self::SCOPES);
+    $client->setUseBatch(TRUE);
+
+    // Set empty json object as a key if necessary.
+    if ($key) {
+      $client->setAuthConfig(json_decode($key, TRUE));
+      $client->authorize();
+    }
+
+    return new Indexing($client);
+  }
+
+}

--- a/public/modules/custom/helfi_google_api/src/GoogleServiceFactory.php
+++ b/public/modules/custom/helfi_google_api/src/GoogleServiceFactory.php
@@ -36,7 +36,6 @@ class GoogleServiceFactory {
     $client->addScope(self::SCOPES);
     $client->setUseBatch(TRUE);
 
-    // Set empty json object as a key if necessary.
     if ($key) {
       $client->setAuthConfig(json_decode($key, TRUE));
       $client->authorize();

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_google_api;
+
+use Google\Client as GoogleClient;
+use Google\Service\Indexing\UrlNotification;
+use Google\Service\Indexing;
+
+class HelfiGoogleApi {
+
+  const END_POINT = 'https://indexing.googleapis.com/v3/urlNotifications:publish';
+
+  const SCOPES = ['https://www.googleapis.com/auth/indexing'];
+
+  public function __construct(
+    private readonly GoogleClient $apiClient
+  ) {
+    // $indexing = new Indexing();
+    // $apiClient->setApplicationName('Helfi_Rekry');
+    //$indexing = new UrlNotification();
+    // $apiClient->setDeveloperKey();
+    // $apiClient->setAuthConfig();
+    // $this->apiClient->setUseBatch(TRUE);
+    // $batch = $this->apiClient->execute();
+
+    // $apiClient->setScopes(self::SCOPES);
+  }
+
+  public function indexJobs(array $jobs, string $type): void {
+  }
+
+}

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -65,7 +65,7 @@ class HelfiGoogleApi {
   public function hasAuthenticationKey(): bool {
     $config = $this->configFactory->get('helfi_google_api.settings');
     $key = $config->get('indexing_api_key') ?: '';
-    return !!$key;
+    return (bool) $key;
   }
 
   /**

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -128,7 +128,7 @@ class HelfiGoogleApi {
    * @return string
    *   The response as a string.
    */
-  public function checkIndexingStatus($url): string {
+  public function checkIndexingStatus(string $url): string {
     $this->initializeApi(FALSE);
 
     $base_url = self::METADATA_ENDPOINT;
@@ -147,8 +147,6 @@ class HelfiGoogleApi {
    *
    * @param bool $batch
    *   Set the client on batch mode.
-   *
-   * @return void
    */
   private function initializeApi(bool $batch = TRUE): void {
     $config = $this->configFactory->get('helfi_google_api.settings');

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -59,6 +59,18 @@ class HelfiGoogleApi {
   }
 
   /**
+   * Does the api key exist.
+   *
+   * @return bool
+   *   Api key exists.
+   */
+  public function hasAuthenticationKey(): bool {
+    $config = $this->configFactory->get('helfi_google_api.settings');
+    $key = $config->get('indexing_api_key') ?: '';
+    return !!$key;
+  }
+
+  /**
    * Send indexing or deindexing request for urls.
    *
    * @param array $urls
@@ -124,6 +136,7 @@ class HelfiGoogleApi {
     $the_url = $base_url . $queryParameter;
 
     $client = $this->indexingService->getClient()->authorize();
+
     $response = $client->get($the_url);
 
     return $response->getBody()->getContents();

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -5,30 +5,95 @@ declare(strict_types=1);
 namespace Drupal\helfi_google_api;
 
 use Google\Client as GoogleClient;
-use Google\Service\Indexing\UrlNotification;
 use Google\Service\Indexing;
+use GuzzleHttp\Psr7\Request;
 
 class HelfiGoogleApi {
 
-  const END_POINT = 'https://indexing.googleapis.com/v3/urlNotifications:publish';
+  const PUBLISH_ENDPOINT = 'https://indexing.googleapis.com/v3/urlNotifications:publish';
+
+  const METADATA_ENDPOINT = 'https://indexing.googleapis.com/v3/urlNotifications/metadata';
+
+  const BATCH_ENDPOINT = 'https://indexing.googleapis.com/batch';
 
   const SCOPES = ['https://www.googleapis.com/auth/indexing'];
 
-  public function __construct(
-    private readonly GoogleClient $apiClient
-  ) {
-    // $indexing = new Indexing();
-    // $apiClient->setApplicationName('Helfi_Rekry');
-    //$indexing = new UrlNotification();
-    // $apiClient->setDeveloperKey();
-    // $apiClient->setAuthConfig();
-    // $this->apiClient->setUseBatch(TRUE);
-    // $batch = $this->apiClient->execute();
+  const UPDATE = 'URL_UPDATED';
 
-    // $apiClient->setScopes(self::SCOPES);
+  // todo Could be URL_REMOVED
+  const DELETE = 'URL_DELETED';
+
+  private Indexing $indexingService;
+
+  public function __construct(
+  ) {
   }
 
-  public function indexJobs(array $jobs, string $type): void {
+  /**
+   * Send update request to indexing api, no more than 100 items at a time.
+   *
+   * @param array $jobs
+   *   Array of job_listing nodes to be indexed or removed from index.
+   *
+   * @return void
+   */
+  public function indexBatch(array $urls, bool $update): void {
+
+    $this->initializeApi();
+    $batch = $this->indexingService->createBatch();
+    $operation = $update ? self::UPDATE : self::DELETE;
+
+    foreach ($urls as $url) {
+      $content = [
+        'type' => $operation,
+        'url' => $url,
+      ];
+
+      $request = new Request(
+        method: 'POST',
+        uri: self::PUBLISH_ENDPOINT,
+        headers: ['Content-Type' => 'multipart/mixed'],
+        body: json_encode($content)
+      );
+
+      $batch->add($request);
+    }
+
+    die('LETS NOT SEND STUFF JUST YET');
+    // $batch->execute();
+  }
+
+  public function checkIndexingStatus($url): string {
+    $base_url = self::METADATA_ENDPOINT;
+    $queryParameter = '?url=' . urlencode($url);
+    $the_url = $base_url . $queryParameter;
+
+    $this->initializeApi(FALSE);
+    $client = $this->indexingService->getClient()->authorize();
+    $response = $client->get($the_url);
+
+    return $response->getBody()->getContents();
+  }
+
+  private function initializeApi($batch = TRUE) {
+    // @todo Get correct key.
+    $key = 'CHANGE THIS';
+    $config = \Drupal::configFactory()->get('helfi_google_api.settings');
+    $key = $config->get('indexing_api_key') ?: '';
+
+    if (!$key) {
+      throw new \Exception('Api key not configured. Unable to proceed.');
+    }
+
+    $client = new GoogleClient();
+    $client->setApplicationName('Helfi_Rekry');
+    // $client->setDeveloperKey($key);
+    $client->setAuthConfig(json_decode($key, TRUE));
+
+    $client->addScope(self::SCOPES);
+    $client->setUseBatch($batch);
+
+    $this->indexingService = new Indexing($client);
   }
 
 }

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -42,15 +42,13 @@ class HelfiGoogleApi {
 
   /**
    * Google indexing service.
-   *
-   * @var Google\Service\Indexing
    */
   private Indexing $indexingService;
 
   /**
    * The constructor.
    *
-   * @param Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   The config factory.
    */
   public function __construct(
@@ -137,7 +135,7 @@ class HelfiGoogleApi {
 
     $client = $this->indexingService->getClient()->authorize();
 
-    $response = $client->get($the_url);
+    $response = $client->request('GET', $the_url);
 
     return $response->getBody()->getContents();
   }

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -93,7 +93,6 @@ class HelfiGoogleApi {
     $responses = $batch->execute();
 
     $errors = [];
-
     foreach ($responses as $key => $response) {
       if ($response instanceof Exception) {
         $errors[] = "$key: {$response->getMessage()}";

--- a/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
+++ b/public/modules/custom/helfi_google_api/src/HelfiGoogleApi.php
@@ -4,41 +4,72 @@ declare(strict_types=1);
 
 namespace Drupal\helfi_google_api;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Google\Client as GoogleClient;
+use Google\Service\Exception;
 use Google\Service\Indexing;
 use GuzzleHttp\Psr7\Request;
 
+/**
+ * A wrapper for Google indexing library.
+ */
 class HelfiGoogleApi {
 
+  /**
+   * Endpoint for sending update and delete requests.
+   */
   const PUBLISH_ENDPOINT = 'https://indexing.googleapis.com/v3/urlNotifications:publish';
 
+  /**
+   * Endpoint for requesting url indexing status.
+   */
   const METADATA_ENDPOINT = 'https://indexing.googleapis.com/v3/urlNotifications/metadata';
 
-  const BATCH_ENDPOINT = 'https://indexing.googleapis.com/batch';
-
+  /**
+   * Api scopes.
+   */
   const SCOPES = ['https://www.googleapis.com/auth/indexing'];
 
+  /**
+   * Request type for update-request (indexing).
+   */
   const UPDATE = 'URL_UPDATED';
 
-  // todo Could be URL_REMOVED
+  /**
+   * Request type for delete request (deindexing).
+   */
   const DELETE = 'URL_DELETED';
 
+  /**
+   * Google indexing service.
+   *
+   * @var Google\Service\Indexing
+   */
   private Indexing $indexingService;
 
+  /**
+   * The constructor.
+   *
+   * @param Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
   public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
   ) {
   }
 
   /**
-   * Send update request to indexing api, no more than 100 items at a time.
+   * Send indexing or deindexing request for urls.
    *
-   * @param array $jobs
-   *   Array of job_listing nodes to be indexed or removed from index.
+   * @param array $urls
+   *   Array of urls to index or deindex.
+   * @param bool $update
+   *   TRUE to index the urls, FALSE for deindexing.
    *
-   * @return void
+   * @return array
+   *   Array which consists of the amount of items sent and array of errors.
    */
-  public function indexBatch(array $urls, bool $update): void {
-
+  public function indexBatch(array $urls, bool $update): array {
     $this->initializeApi();
     $batch = $this->indexingService->createBatch();
     $operation = $update ? self::UPDATE : self::DELETE;
@@ -59,26 +90,56 @@ class HelfiGoogleApi {
       $batch->add($request);
     }
 
-    die('LETS NOT SEND STUFF JUST YET');
-    // $batch->execute();
+    $responses = $batch->execute();
+
+    $errors = [];
+
+    foreach ($responses as $key => $response) {
+      if ($response instanceof Exception) {
+        $errors[] = "$key: {$response->getMessage()}";
+      }
+    }
+
+    return [
+      'count' => count($urls),
+      'errors' => $errors,
+    ];
   }
 
+  /**
+   * Request url indexing status.
+   *
+   * Returns the dates of last update and delete requests.
+   *
+   * @param string $url
+   *   The url which indexing status you want to request.
+   *
+   * @return string
+   *   The response as a string.
+   */
   public function checkIndexingStatus($url): string {
+    $this->initializeApi(FALSE);
+
     $base_url = self::METADATA_ENDPOINT;
     $queryParameter = '?url=' . urlencode($url);
     $the_url = $base_url . $queryParameter;
 
-    $this->initializeApi(FALSE);
     $client = $this->indexingService->getClient()->authorize();
     $response = $client->get($the_url);
 
     return $response->getBody()->getContents();
   }
 
-  private function initializeApi($batch = TRUE) {
-    // @todo Get correct key.
-    $key = 'CHANGE THIS';
-    $config = \Drupal::configFactory()->get('helfi_google_api.settings');
+  /**
+   * Set up the client.
+   *
+   * @param bool $batch
+   *   Set the client on batch mode.
+   *
+   * @return void
+   */
+  private function initializeApi(bool $batch = TRUE): void {
+    $config = $this->configFactory->get('helfi_google_api.settings');
     $key = $config->get('indexing_api_key') ?: '';
 
     if (!$key) {
@@ -87,7 +148,6 @@ class HelfiGoogleApi {
 
     $client = new GoogleClient();
     $client->setApplicationName('Helfi_Rekry');
-    // $client->setDeveloperKey($key);
     $client->setAuthConfig(json_decode($key, TRUE));
 
     $client->addScope(self::SCOPES);

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -177,7 +177,7 @@ class JobIndexingService {
 
     $language = $entity->language();
 
-    $baseUrl = $this->generateFromRoute('<front>', [], ['absolute' => TRUE, 'language' => $language]);
+    $baseUrl = $this->urlGenerator->generateFromRoute('<front>', [], ['absolute' => TRUE, 'language' => $language]);
     $job_alias = $this->aliasManager->getAliasByPath("/node/{$entity->id()}", $language->getId());
 
     $query = $this->entityTypeManager->getStorage('redirect')->getQuery();

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -353,7 +353,7 @@ class JobIndexingService {
    */
   private function handleDebugMessage(Response $response) {
     if ($response->isDryRun()) {
-      $this->logger->debug('Request would have sent following urls to api: '. json_encode($response->getUrls()));
+      $this->logger->debug('Request would have sent following urls to api: ' . json_encode($response->getUrls()));
     }
   }
 

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -5,37 +5,199 @@ declare(strict_types=1);
 namespace Drupal\helfi_google_api;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
-use Drupal\helfi_google_api\HelfiGoogleApi;
+use Drupal\path_alias\AliasManagerInterface;
+use Drupal\redirect\Entity\Redirect;
+use GuzzleHttp\Exception\GuzzleException;
 
 class JobIndexingService {
 
   public function __construct(
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly HelfiGoogleApi $helfiGoogleApi,
+    private readonly AliasManagerInterface $aliasManager,
   ) {
   }
 
   /**
-   * Update any jobs that were either published or unpublished today.
+   * Send single item to google for indexing.
+   *
+   * @param string $url
+   *   Url to index.
    *
    * @return void
    */
-  public function indexUpdatedJobs(): void {
-    $storage = $this->entityTypeManager
-      ->getStorage('job_listing');
-    $startOfToday = strtotime('today 00:05');
-    $startOfYesterday = strtotime('yesterday 00:05');
+  public function indexItem(string $url) {
+    $this->helfiGoogleApi->indexBatch([$url], TRUE);
+  }
 
-    $this->helfiGoogleApi->indexJobs();
-    $publishedJobIds = $storage->getQuery()
-      ->condition('publish_on', $startOfToday, '>=')
+  public function deindexItem(string $url) {
+    $this->helfiGoogleApi->indexBatch([$url], FALSE);
+  }
+
+  public function checkItemIndexStatus(string $url): string {
+    try {
+      return $this->helfiGoogleApi->checkIndexingStatus($url);
+    }
+    catch (GuzzleException $e) {
+      throw new \Exception($e->getMessage(), $e->getCode());
+    }
+  }
+
+  /**
+   * Update any jobs that were published today.
+   *
+   * @return void
+   */
+  public function indexJobs(): void {
+    $storage = $this->entityTypeManager
+      ->getStorage('node');
+    $startOfToday = strtotime('today 00:00:00');
+    $endOfToday = strtotime('today 23:59:59');
+
+    // Etsi nodet joiden publish_on on tänään
+    // TAI ei oo tänään mutta on luotu tänään
+
+    $jobIds = $storage->getQuery()
+      // ->condition('publish_on', $startOfToday, '>=')
+      // ->condition('publish_on', $endOfToday, '<=')
       ->condition('status', 1)
+      ->condition('type', 'job_listing')
+      ->latestRevision()
       ->accessCheck(FALSE)
       ->execute();
-    $publishedJobs = $storage->loadMultiple($publishedJobIds);
 
-    $this->helfiGoogleApi->indexJobs($publishedJobs, 'update');
+    if (!$jobIds) {
+      return;
+    }
 
+    $jobs = $storage->loadMultiple($jobIds);
+    $urls = $this->prepareUrls($jobs);
+
+    $this->helfiGoogleApi->indexJobsBatch($urls);
+  }
+
+  public function deleteIndexedJobs() {
+
+    $storage = $this->entityTypeManager
+      ->getStorage('node');
+    $startOfToday = strtotime('today 00:00:00');
+    $endOfToday = strtotime('today 23:59:59');
+
+    // Etsi nodet joiden unpublish on on tänään
+    $jobIds = $storage->getQuery()
+      ->condition('unpublish_on', $startOfToday, '>=')
+      ->condition('unpublish_on', $endOfToday, '<=')
+      ->condition('status', 0)
+      ->condition('type', 'job_listing')
+      ->latestRevision()
+      ->accessCheck(FALSE)
+      ->execute();
+
+    if (!$jobIds) {
+      return;
+    }
+
+    $jobs = $storage->loadMultiple($jobIds);
+
+    // hae redirectit
+    $redirect = $this->getRedirects($jobs);
+
+    // kaiva se urli sieltä
+    // lähetä googlelle
+    // poista redirect
+
+    // $this->helfiGoogleApi->indexJobsBatch($urls);
+    // $urls = $this->getUrls($jobs);
+
+    // Redirect::load()
+
+  }
+
+  // TODO get urls function should not create redirects
+  private function prepareUrls(array $jobs, array $langcodes = ['fi', 'en', 'sv']): array {
+    $result = [];
+
+    $now = strtotime('now');
+
+    foreach ($jobs as $job) {
+
+      foreach($langcodes as $langcode) {
+        if ($job->hasTranslation($langcode)) {
+          $job = $job->getTranslation($langcode);
+          $alias = $this->aliasManager->getAliasByPath("/node/{$job->id()}", $langcode);
+          $temp_alias = "{$alias}-{$now}";
+
+          $redirect = Redirect::create([
+            'redirect_source' => ltrim($temp_alias, '/'),
+            'redirect_redirect' => "internal:/node/{$job->id()}",
+            'language' => $langcode,
+            'status_code' => 301,
+            'title' => $job->getTitle(),
+          ]);
+
+          // $redirect->setRedirect( "/node/{$job->id()}", [], ['redirect_title' => $job->getTitle()]);
+          $save_status = $redirect->save();
+
+          if ($save_status === SAVED_NEW) {
+            $index_url = "{$job->toUrl()->setAbsolute(TRUE)->toString()}-{$now}";
+            $result[] = $index_url;
+          }
+
+        }
+      }
+    }
+
+    return $result;
+  }
+
+  /**
+   * Delete a temporary redirect.
+   *
+   * @param array $jobs
+   *   Array of nodes.
+   *
+   * @return array
+   */
+  private function deleteRedirect(array $jobs): array {
+    $result = [];
+    $langcodes = ['fi', 'en', 'sv'];
+
+    foreach ($jobs as $job) {
+      foreach($langcodes as $langcode) {
+        if ($job->hasTranslation($langcode)) {
+          $job = $job->getTranslation($langcode);
+
+          $redirectIds = \Drupal::entityQuery('redirect')
+            ->condition('redirect_redirect__uri', "internal:/node/{$job->id()}")
+            ->condition('status_code', 301)
+            ->condition('language', $langcode)
+            ->execute();
+
+          $redirects = Redirect::loadMultiple($redirectIds);
+          /** @var Redirect $redirect */
+          foreach ($redirects as $redirect) {
+            $alias = $this->aliasManager->getAliasByPath("/node/{$job->id()}", $langcode);
+            $source = $redirect->getSourceUrl();
+            if (!str_contains($source, "$alias-")) {
+              continue;
+            }
+
+            $result[] = $source;
+            try {
+              $redirect->delete();
+            }
+            catch(\Exception $e) {
+              // Add logging.
+            }
+
+          }
+        }
+      }
+
+      return $result;
+    }
+
+    return $result;
   }
 
 }

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -86,7 +86,6 @@ class JobIndexingService {
     return $result;
   }
 
-
   /**
    * Handle entity indexing request.
    *

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -98,9 +98,9 @@ class JobIndexingService {
   }
 
   /**
-   * Handle entity indexing request
+   * Handle entity indexing request.
    *
-   * @param JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   Entity to request deindexing for.
    *
    * @return array
@@ -132,8 +132,8 @@ class JobIndexingService {
     try {
       $result = $this->deindexItems([$url_to_deindex]);
     }
-    catch(GuzzleException $e) {
-      $message = "Request failed with code {$e->getCode()}: {$e->getMessage()}"
+    catch (GuzzleException $e) {
+      $message = "Request failed with code {$e->getCode()}: {$e->getMessage()}";
       $this->logger->error($message);
       throw new \Exception($message);
     }
@@ -164,7 +164,7 @@ class JobIndexingService {
   /**
    * If entity seems to be indexed, send a status query.
    *
-   * @param JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   Entity to check.
    *
    * @return array
@@ -205,7 +205,7 @@ class JobIndexingService {
     try {
       $response = $this->helfiGoogleApi->checkIndexingStatus($url_to_check);
     }
-    catch(GuzzleException $e) {
+    catch (GuzzleException $e) {
       $this->logger->error("Request failed with code {$e->getCode()}: {$e->getMessage()}");
     }
     catch (\Exception $e) {

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -274,7 +274,7 @@ class JobIndexingService {
     ]);
 
     // If the api is not set up, no need to create the redirect.
-    if ($this->googleApi->isEnabled()) {
+    if ($this->googleApi->isDryRun()) {
       $redirect->save();
     }
 
@@ -306,7 +306,7 @@ class JobIndexingService {
     $redirects = Redirect::loadMultiple($redirectIds);
 
     // For debugging purposes, dbugging won't save the redirect.
-    if (!$redirects && !$this->googleApi->isEnabled()) {
+    if (!$redirects && !$this->googleApi->isDryRun()) {
       return $this->createTemporaryRedirectUrl($entity, $langcode)['redirect'];
     }
 

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -144,6 +144,8 @@ class JobIndexingService {
   /**
    * Check url indexing status.
    *
+   * Status check request uses the api quota.
+   *
    * @param string $url
    *   An url to check.
    *
@@ -156,6 +158,8 @@ class JobIndexingService {
 
   /**
    * If entity seems to be indexed, send a status query.
+   *
+   * Status check request uses the api quota.
    *
    * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   Entity to check.

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -356,7 +356,7 @@ class JobIndexingService {
    * @param Response $response
    *   The response.
    */
-  private function handleDebugMessage(Response $response) {
+  private function handleDebugMessage(Response $response): void {
     if ($response->isDryRun()) {
       $this->logger->debug('Request would have sent following urls to api: ' . json_encode($response->getUrls()));
     }

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -44,7 +44,7 @@ class JobIndexingService {
   /**
    * Send indexing request to google.
    *
-   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   Entity which indexing should be requested.
    *
    * @return array
@@ -198,22 +198,23 @@ class JobIndexingService {
       }
     }
 
-    if (!$correct_redirect) {
+    if (!isset($correct_redirect)) {
       throw new \Exception('Entity doesn\'t have temporary redirect.');
     }
 
     $url_to_check = $baseUrl . $correct_redirect->getSourceUrl();
     try {
-      $response = $this->helfiGoogleApi->checkIndexingStatus($url_to_check);
+      return $this->helfiGoogleApi->checkIndexingStatus($url_to_check);
     }
     catch (GuzzleException $e) {
       $this->logger->error("Request failed with code {$e->getCode()}: {$e->getMessage()}");
+      throw new \Exception("Request failed with code {$e->getCode()}: {$e->getMessage()}");
     }
     catch (\Exception $e) {
       $this->logger->error('Error while checking indexing status: ' . $e->getMessage());
+      throw new \Exception("Something went wrong: {$e->getMessage()}");
     }
 
-    return $response;
   }
 
   /**
@@ -223,7 +224,7 @@ class JobIndexingService {
    * Once delete-request is sent, the url cannot be indexed again using the api.
    * Hence we should not use the original url.
    *
-   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity to check.
    * @param string $langcode
    *   The language code.
@@ -262,7 +263,7 @@ class JobIndexingService {
    * Once delete request is sent, the url cannot be indexed again using the api.
    * Hence we should not use the original url.
    *
-   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity to index.
    * @param string $langcode
    *   The language code.
@@ -289,12 +290,12 @@ class JobIndexingService {
   /**
    * Get the temporary redirect url.
    *
-   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity to index.
    * @param string $langcode
    *   The language code.
    *
-   * @return Drupal\redirect\Entity\Redirect|null
+   * @return \Drupal\redirect\Entity\Redirect|null
    *   The redirect object.
    */
   public function getExistingTemporaryRedirect(JobListing $entity, string $langcode): Redirect|null {
@@ -327,7 +328,7 @@ class JobIndexingService {
   /**
    * Get the alias for an entity.
    *
-   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
+   * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity.
    * @param string $langcode
    *   The language code.

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -114,7 +114,14 @@ class JobIndexingService {
 
     $url_to_deindex = $base_url . $redirect->getSourceUrl();
 
-    return $this->deindexItems([$url_to_deindex]);
+    try {
+      $response = $this->deindexItems([$url_to_deindex]);
+      $redirect->delete();
+      return $response;
+    } catch(GuzzleException $e) {
+      $this->logger->error("Error while deindexing entity id {$entity->id()}: {$e->getMessage()}");
+      throw new \Exception('Failed de-index redirect.');
+    }
   }
 
   /**
@@ -263,7 +270,7 @@ class JobIndexingService {
    * @return Redirect|null
    *   The redirect object.
    */
-  private function getExistingTemporaryRedirect(JobListing $entity, string $langcode): Redirect|null {
+  public function getExistingTemporaryRedirect(JobListing $entity, string $langcode): Redirect|null {
     $job_alias = $this->getEntityAlias($entity, $langcode);
 
     $query = $this->entityTypeManager->getStorage('redirect')
@@ -275,6 +282,10 @@ class JobIndexingService {
       ->accessCheck(FALSE)
       ->execute();
     $redirects = Redirect::loadMultiple($redirectIds);
+
+    if (!$redirects) {
+      return NULL;
+    }
 
     foreach ($redirects as $redirect) {
       $source = $redirect->getSourceUrl();
@@ -299,163 +310,6 @@ class JobIndexingService {
    */
   private function getEntityAlias(JobListing $entity, string $langcode): string {
     return $this->aliasManager->getAliasByPath("/node/{$entity->id()}", $langcode);
-  }
-
-
-  /**
-   * Update any jobs that were published today.
-   *
-   * @return void
-   */
-  public function indexJobs(): void {
-    $storage = $this->entityTypeManager
-      ->getStorage('node');
-    $startOfToday = strtotime('today 00:00:00');
-    $endOfToday = strtotime('today 23:59:59');
-
-    // Etsi nodet joiden publish_on on tänään
-    // TAI ei oo tänään mutta on luotu tänään
-
-    $jobIds = $storage->getQuery()
-      // ->condition('publish_on', $startOfToday, '>=')
-      // ->condition('publish_on', $endOfToday, '<=')
-      ->condition('status', 1)
-      ->condition('type', 'job_listing')
-      ->latestRevision()
-      ->accessCheck(FALSE)
-      ->execute();
-
-    if (!$jobIds) {
-      return;
-    }
-
-    $jobs = $storage->loadMultiple($jobIds);
-    $urls = $this->prepareUrls($jobs);
-
-    $this->helfiGoogleApi->indexJobsBatch($urls);
-  }
-
-  public function deleteIndexedJobs() {
-
-    $storage = $this->entityTypeManager
-      ->getStorage('node');
-    $startOfToday = strtotime('today 00:00:00');
-    $endOfToday = strtotime('today 23:59:59');
-
-    // Etsi nodet joiden unpublish on on tänään
-    $jobIds = $storage->getQuery()
-      ->condition('unpublish_on', $startOfToday, '>=')
-      ->condition('unpublish_on', $endOfToday, '<=')
-      ->condition('status', 0)
-      ->condition('type', 'job_listing')
-      ->latestRevision()
-      ->accessCheck(FALSE)
-      ->execute();
-
-    if (!$jobIds) {
-      return;
-    }
-
-    $jobs = $storage->loadMultiple($jobIds);
-
-    // hae redirectit
-    $redirect = $this->getRedirects($jobs);
-
-    // kaiva se urli sieltä
-    // lähetä googlelle
-    // poista redirect
-
-    // $this->helfiGoogleApi->indexJobsBatch($urls);
-    // $urls = $this->getUrls($jobs);
-
-    // Redirect::load()
-
-  }
-
-  private function prepareUrls(array $jobs, array $langcodes = ['fi', 'en', 'sv']): array {
-    $result = [];
-
-    $now = strtotime('now');
-
-    foreach ($jobs as $job) {
-
-      foreach($langcodes as $langcode) {
-        if ($job->hasTranslation($langcode)) {
-          $job = $job->getTranslation($langcode);
-          $alias = $this->aliasManager->getAliasByPath("/node/{$job->id()}", $langcode);
-          $temp_alias = "{$alias}-{$now}";
-
-          $redirect = Redirect::create([
-            'redirect_source' => ltrim($temp_alias, '/'),
-            'redirect_redirect' => "internal:/node/{$job->id()}",
-            'language' => $langcode,
-            'status_code' => 301,
-            'title' => $job->getTitle(),
-          ]);
-
-          // $redirect->setRedirect( "/node/{$job->id()}", [], ['redirect_title' => $job->getTitle()]);
-          $save_status = $redirect->save();
-
-          if ($save_status === SAVED_NEW) {
-            $index_url = "{$job->toUrl()->setAbsolute(TRUE)->toString()}-{$now}";
-            $result[] = $index_url;
-          }
-
-        }
-      }
-    }
-
-    return $result;
-  }
-
-  /**
-   * Delete a temporary redirect.
-   *
-   * @param array $jobs
-   *   Array of nodes.
-   *
-   * @return array
-   */
-  private function deleteRedirect(array $jobs): array {
-    $result = [];
-    $langcodes = ['fi', 'en', 'sv'];
-
-    foreach ($jobs as $job) {
-      foreach($langcodes as $langcode) {
-        if ($job->hasTranslation($langcode)) {
-          $job = $job->getTranslation($langcode);
-
-          $redirectIds = \Drupal::entityQuery('redirect')
-            ->condition('redirect_redirect__uri', "internal:/node/{$job->id()}")
-            ->condition('status_code', 301)
-            ->condition('language', $langcode)
-            ->execute();
-
-          $redirects = Redirect::loadMultiple($redirectIds);
-          /** @var Redirect $redirect */
-          foreach ($redirects as $redirect) {
-            $alias = $this->aliasManager->getAliasByPath("/node/{$job->id()}", $langcode);
-            $source = $redirect->getSourceUrl();
-            if (!str_contains($source, "$alias-")) {
-              continue;
-            }
-
-            $result[] = $source;
-            try {
-              $redirect->delete();
-            }
-            catch(\Exception $e) {
-              // Add logging.
-            }
-
-          }
-        }
-      }
-
-      return $result;
-    }
-
-    return $result;
   }
 
 }

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_google_api;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\helfi_google_api\HelfiGoogleApi;
+
+class JobIndexingService {
+
+  public function __construct(
+    private readonly EntityTypeManagerInterface $entityTypeManager,
+    private readonly HelfiGoogleApi $helfiGoogleApi,
+  ) {
+  }
+
+  /**
+   * Update any jobs that were either published or unpublished today.
+   *
+   * @return void
+   */
+  public function indexUpdatedJobs(): void {
+    $storage = $this->entityTypeManager
+      ->getStorage('job_listing');
+    $startOfToday = strtotime('today 00:05');
+    $startOfYesterday = strtotime('yesterday 00:05');
+
+    $this->helfiGoogleApi->indexJobs();
+    $publishedJobIds = $storage->getQuery()
+      ->condition('publish_on', $startOfToday, '>=')
+      ->condition('status', 1)
+      ->accessCheck(FALSE)
+      ->execute();
+    $publishedJobs = $storage->loadMultiple($publishedJobIds);
+
+    $this->helfiGoogleApi->indexJobs($publishedJobs, 'update');
+
+  }
+
+}

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -20,7 +20,7 @@ class JobIndexingService {
   use AutowireTrait;
 
   public function __construct(
-    private readonly HelfiGoogleApi $helfiGoogleApi,
+    private readonly GoogleApi $googleApi,
     private readonly EntityTypeManagerInterface $entityTypeManager,
     private readonly AliasManagerInterface $aliasManager,
     private readonly UrlGeneratorInterface $urlGenerator,
@@ -41,7 +41,7 @@ class JobIndexingService {
    */
   public function handleIndexingRequest(array $urls, bool $update): array {
     try {
-      return $this->helfiGoogleApi->indexBatch($urls, $update);
+      return $this->googleApi->indexBatch($urls, $update);
     }
     catch (GuzzleException $e) {
       $message = "Request failed with code {$e->getCode()}: {$e->getMessage()}";
@@ -60,7 +60,7 @@ class JobIndexingService {
    *   Array of containing total count indexed and errors.
    */
   public function indexEntity(JobListing $entity): array {
-    if (!$this->helfiGoogleApi->hasAuthenticationKey()) {
+    if (!$this->googleApi->hasAuthenticationKey()) {
       throw new \Exception('Api key not set.');
     }
 
@@ -96,7 +96,7 @@ class JobIndexingService {
    *   Array: 'count': int, 'errors': array
    */
   public function deindexEntity(JobListing $entity): array {
-    if (!$this->helfiGoogleApi->hasAuthenticationKey()) {
+    if (!$this->googleApi->hasAuthenticationKey()) {
       throw new \Exception('Api key not set.');
     }
 
@@ -140,7 +140,7 @@ class JobIndexingService {
    *   Status as a string.
    */
   public function checkItemIndexStatus(string $url): string {
-    return $this->helfiGoogleApi->checkIndexingStatus($url);
+    return $this->googleApi->checkIndexingStatus($url);
   }
 
   /**
@@ -153,7 +153,7 @@ class JobIndexingService {
    *   The url index status as a string.
    */
   public function checkEntityIndexStatus(JobListing $entity): string {
-    if (!$this->helfiGoogleApi->hasAuthenticationKey()) {
+    if (!$this->googleApi->hasAuthenticationKey()) {
       throw new \Exception('Api key not set.');
     }
 
@@ -186,15 +186,15 @@ class JobIndexingService {
 
     $url_to_check = $baseUrl . $correct_redirect->getSourceUrl();
     try {
-      return $this->helfiGoogleApi->checkIndexingStatus($url_to_check);
+      return $this->googleApi->checkIndexingStatus($url_to_check);
     }
     catch (GuzzleException $e) {
       $this->logger->error("Request failed with code {$e->getCode()}: {$e->getMessage()}");
-      throw new \Exception("Request failed with code {$e->getCode()}: {$e->getMessage()}");
+      throw $e;
     }
     catch (\Exception $e) {
       $this->logger->error('Error while checking indexing status: ' . $e->getMessage());
-      throw new \Exception("Something went wrong: {$e->getMessage()}");
+      throw $e;
     }
 
   }

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -51,11 +51,12 @@ class JobIndexingService {
    *   Array of containing total count indexed and errors.
    */
   public function indexEntity(JobListing $entity): array {
-    $langcode = $entity->language()->getId();
-    $results = [];
+    if (!$this->helfiGoogleApi->hasAuthenticationKey()) {
+      throw new \Exception('Api key not set.');
+    }
 
-    // If the actual url is deindexed, it can't be reindexed again.
-    // If entity has a temporary redirect, it most likely has already been indexed already.
+    $langcode = $entity->language()->getId();
+
     $hasRedirect = $this->temporaryRedirectExists($entity, $langcode);
     if ($hasRedirect) {
       throw new \Exception('Already indexed.');
@@ -64,16 +65,24 @@ class JobIndexingService {
     // Create temporary redirect for the entity.
     $indexing_url = $this->createTemporaryRedirectUrl($entity, $langcode);
 
-    $result = $this->indexItems([$indexing_url]);
+    try {
+      $result = $this->indexItems([$indexing_url]);
+    }
+    catch (GuzzleException $e) {
+      $message = "Request failed with code {$e->getCode()}: {$e->getMessage()}";
+      $this->logger->error($message);
+      throw new \Exception($message);
+    }
 
     if ($result['errors']) {
-      // Some of the urls failed
-      // log
+      $total = $result['count'];
+      $error_count = count($result['errors']);
+      $error_string = json_encode($result['errors']);
+      $this->logger->error("Unable to index $error_count/$total items: $error_string");
     }
 
     return $result;
   }
-
 
   /**
    * Send urls to Google for deindexing.
@@ -84,7 +93,7 @@ class JobIndexingService {
    * @return array
    *   Array: 'count': int, 'errors': array.
    */
-  public function deindexItems(array $urls): array  {
+  public function deindexItems(array $urls): array {
     return $this->helfiGoogleApi->indexBatch($urls, FALSE);
   }
 
@@ -98,30 +107,45 @@ class JobIndexingService {
    *   Array: 'count': int, 'errors': array
    */
   public function deindexEntity(JobListing $entity): array {
+    if (!$this->helfiGoogleApi->hasAuthenticationKey()) {
+      throw new \Exception('Api key not set.');
+    }
+
     $language = $entity->language();
     $redirect = $this->getExistingTemporaryRedirect($entity, $language->getId());
     if (!$redirect) {
-      // Log, the item seems not to be indexed.
-      // Return.
-      throw new \Exception();
+      $this->logger->error("Entity of id {$entity->id()} doesn't have the required temporary redirect.");
+      throw new \Exception("Entity of id {$entity->id()} doesn't have the required temporary redirect.");
     }
 
     $base_url = $this->urlGenerator->generateFromRoute(
       '<front>',
       [],
-      ['absolute' => TRUE,'language' => $language]
+      [
+        'absolute' => TRUE,
+        'language' => $language,
+      ]
     );
 
     $url_to_deindex = $base_url . $redirect->getSourceUrl();
 
     try {
-      $response = $this->deindexItems([$url_to_deindex]);
-      $redirect->delete();
-      return $response;
-    } catch(GuzzleException $e) {
-      $this->logger->error("Error while deindexing entity id {$entity->id()}: {$e->getMessage()}");
-      throw new \Exception('Failed de-index redirect.');
+      $result = $this->deindexItems([$url_to_deindex]);
     }
+    catch(GuzzleException $e) {
+      $message = "Request failed with code {$e->getCode()}: {$e->getMessage()}"
+      $this->logger->error($message);
+      throw new \Exception($message);
+    }
+
+    if ($result['errors']) {
+      $total = $result['count'];
+      $error_count = count($result['errors']);
+      $error_string = json_encode($result['errors']);
+      $this->logger->error("Unable to index $error_count/$total items: $error_string");
+    }
+
+    return $result;
   }
 
   /**
@@ -134,21 +158,22 @@ class JobIndexingService {
    *   Status as a string.
    */
   public function checkItemIndexStatus(string $url): string {
-    try {
-      return $this->helfiGoogleApi->checkIndexingStatus($url);
-    }
-    catch (GuzzleException $e) {
-      throw new \Exception($e->getMessage(), $e->getCode());
-    }
+    return $this->helfiGoogleApi->checkIndexingStatus($url);
   }
 
   /**
    * If entity seems to be indexed, send a status query.
    *
    * @param JobListing $entity
+   *   Entity to check.
+   *
    * @return array
    */
   public function checkEntityIndexStatus(JobListing $entity): string {
+    if (!$this->helfiGoogleApi->hasAuthenticationKey()) {
+      throw new \Exception('Api key not set.');
+    }
+
     $language = $entity->language();
 
     $baseUrl = $this->generateFromRoute('<front>', [], ['absolute' => TRUE, 'language' => $language]);
@@ -173,30 +198,31 @@ class JobIndexingService {
     }
 
     if (!$correct_redirect) {
-      // HAS NOT BEEN SENT AFAIK
+      throw new \Exception('Entity doesn\'t have temporary redirect.');
     }
 
     $url_to_check = $baseUrl . $correct_redirect->getSourceUrl();
     try {
       $response = $this->helfiGoogleApi->checkIndexingStatus($url_to_check);
     }
+    catch(GuzzleException $e) {
+      $this->logger->error("Request failed with code {$e->getCode()}: {$e->getMessage()}");
+    }
     catch (\Exception $e) {
-      // REQUEST FAILED
-
+      $this->logger->error('Error while checking indexing status: ' . $e->getMessage());
     }
 
     return $response;
-
   }
 
   /**
    * Does the entity have a temporary redirect.
    *
    * Temporary redirect is created for all entities before requesting indexing.
-   * Once delete request is sent, the url cannot be indexed again using the api.
+   * Once delete-request is sent, the url cannot be indexed again using the api.
    * Hence we should not use the original url.
    *
-   * @param JobListing $entity
+   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity to check.
    * @param string $langcode
    *   The language code.
@@ -204,7 +230,7 @@ class JobIndexingService {
    * @return bool
    *   Has temporary redirect.
    */
-  private function temporaryRedirectExists(JobListing $entity, string $langcode): bool {
+  public function temporaryRedirectExists(JobListing $entity, string $langcode): bool {
     $job_alias = $this->getEntityAlias($entity, $langcode);
 
     $query = $this->entityTypeManager->getStorage('redirect')
@@ -235,7 +261,7 @@ class JobIndexingService {
    * Once delete request is sent, the url cannot be indexed again using the api.
    * Hence we should not use the original url.
    *
-   * @param JobListing $entity
+   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity to index.
    * @param string $langcode
    *   The language code.
@@ -243,7 +269,7 @@ class JobIndexingService {
    * @return string
    *   Absolute url that can be sent for indexing.
    */
-  private function createTemporaryRedirectUrl(JobListing $entity, string $langcode): string {
+  public function createTemporaryRedirectUrl(JobListing $entity, string $langcode): string {
     $alias = $this->getEntityAlias($entity, $langcode);
     $now = strtotime('now');
     $temp_alias = "$alias-$now";
@@ -262,12 +288,12 @@ class JobIndexingService {
   /**
    * Get the temporary redirect url.
    *
-   * @param JobListing $entity
+   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity to index.
    * @param string $langcode
    *   The language code.
    *
-   * @return Redirect|null
+   * @return Drupal\redirect\Entity\Redirect|null
    *   The redirect object.
    */
   public function getExistingTemporaryRedirect(JobListing $entity, string $langcode): Redirect|null {
@@ -300,7 +326,7 @@ class JobIndexingService {
   /**
    * Get the alias for an entity.
    *
-   * @param JobListing $entity
+   * @param Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   The entity.
    * @param string $langcode
    *   The language code.

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -167,7 +167,8 @@ class JobIndexingService {
    * @param \Drupal\helfi_rekry_content\Entity\JobListing $entity
    *   Entity to check.
    *
-   * @return array
+   * @return string
+   *   The url index status as a string.
    */
   public function checkEntityIndexStatus(JobListing $entity): string {
     if (!$this->helfiGoogleApi->hasAuthenticationKey()) {

--- a/public/modules/custom/helfi_google_api/src/JobIndexingService.php
+++ b/public/modules/custom/helfi_google_api/src/JobIndexingService.php
@@ -228,6 +228,11 @@ class JobIndexingService {
    *   Has temporary redirect.
    */
   public function hasTemporaryRedirect(JobListing $entity, string $langcode): bool {
+    // In case of dry run, we can always say FALSE.
+    if ($this->googleApi->isDryRun()) {
+      return FALSE;
+    }
+
     $job_alias = $this->getEntityAlias($entity, $langcode);
 
     $query = $this->entityTypeManager->getStorage('redirect')

--- a/public/modules/custom/helfi_google_api/src/Response.php
+++ b/public/modules/custom/helfi_google_api/src/Response.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_google_api;
+
+/**
+ * Simple response class to hold the relevant response data.
+ */
+class Response {
+
+  /**
+   * The constructor.
+   *
+   * @param array $urls
+   *   Url which were indexed.
+   * @param array $errors
+   *   Errors per url.
+   * @param bool $debug
+   *   The request was not sent.
+   */
+  public function __construct(
+    private array $urls,
+    private array $errors = [],
+    private bool $debug = FALSE,
+  ) {
+  }
+
+  /**
+   * Get request urls.
+   *
+   * @return array
+   *   the urls.
+   */
+  public function getUrls(): array {
+    return $this->urls;
+  }
+
+  /**
+   * Get the errors.
+   *
+   * @return array
+   *   Errors for each url.
+   */
+  public function getErrors(): array {
+    return $this->errors;
+  }
+
+  /**
+   * The request was not actually sent.
+   *
+   * Either the api key is not set or
+   * in settings config, enabled in false.
+   *
+   * @return bool
+   *   This is a debug run.
+   */
+  public function isDebug(): bool {
+    return $this->debug;
+  }
+
+}

--- a/public/modules/custom/helfi_google_api/src/Response.php
+++ b/public/modules/custom/helfi_google_api/src/Response.php
@@ -16,13 +16,13 @@ class Response {
    *   Url which were indexed.
    * @param array $errors
    *   Errors per url.
-   * @param bool $debug
+   * @param bool $dryRun
    *   The request was not sent.
    */
   public function __construct(
     private array $urls,
     private array $errors = [],
-    private bool $debug = FALSE,
+    private bool $dryRun = FALSE,
   ) {
   }
 
@@ -55,8 +55,8 @@ class Response {
    * @return bool
    *   This is a debug run.
    */
-  public function isDebug(): bool {
-    return $this->debug;
+  public function isDryRun(): bool {
+    return $this->dryRun;
   }
 
 }

--- a/public/modules/custom/helfi_rekry_content/src/Entity/JobListing.php
+++ b/public/modules/custom/helfi_rekry_content/src/Entity/JobListing.php
@@ -7,7 +7,7 @@ namespace Drupal\helfi_rekry_content\Entity;
 use Drupal\node\Entity\Node;
 
 /**
- * Bundle class for hel_map paragraph.
+ * Bundle class for JobListing paragraph.
  */
 class JobListing extends Node {
 

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -3,5 +3,6 @@
 $config['openid_connect.client.tunnistamo']['settings']['is_production'] = TRUE;
 $config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/avoimet-tyopaikat/openid-connect/tunnistamo';
 $config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE_INDEXING_API_KEY');
+
 // Remove the comment when it's time to enable the feature on production
-// $config['helfi_google_api.settings']['enabled'] = getenv('APP_ENV') === 'production';
+// $config['helfi_google_api.settings']['dry_run'] = TRUE;

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -2,3 +2,4 @@
 
 $config['openid_connect.client.tunnistamo']['settings']['is_production'] = TRUE;
 $config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/avoimet-tyopaikat/openid-connect/tunnistamo';
+$config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE-INDEXING-API-KEY');

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -3,4 +3,5 @@
 $config['openid_connect.client.tunnistamo']['settings']['is_production'] = TRUE;
 $config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/avoimet-tyopaikat/openid-connect/tunnistamo';
 $config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE_INDEXING_API_KEY');
-$config['helfi_google_api.settings']['enabled'] = getenv('APP_ENV') === 'production';
+// Remove the comment when it's time to enable the feature on production
+// $config['helfi_google_api.settings']['enabled'] = getenv('APP_ENV') === 'production';

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -2,4 +2,4 @@
 
 $config['openid_connect.client.tunnistamo']['settings']['is_production'] = TRUE;
 $config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/avoimet-tyopaikat/openid-connect/tunnistamo';
-$config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE-INDEXING-API-KEY');
+$config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE_INDEXING_API_KEY');

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -5,4 +5,4 @@ $config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/avoimet-tyopaika
 $config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE_INDEXING_API_KEY');
 
 // Remove the comment when it's time to enable the feature on production
-// $config['helfi_google_api.settings']['dry_run'] = TRUE;
+// $config['helfi_google_api.settings']['dry_run'] = FALSE;

--- a/public/sites/default/production.settings.php
+++ b/public/sites/default/production.settings.php
@@ -3,3 +3,4 @@
 $config['openid_connect.client.tunnistamo']['settings']['is_production'] = TRUE;
 $config['helfi_proxy.settings']['tunnistamo_return_url'] = '/fi/avoimet-tyopaikat/openid-connect/tunnistamo';
 $config['helfi_google_api.settings']['indexing_api_key'] = getenv('GOOGLE_INDEXING_API_KEY');
+$config['helfi_google_api.settings']['enabled'] = getenv('APP_ENV') === 'production';


### PR DESCRIPTION
# [UHF-8706](https://helsinkisolutionoffice.atlassian.net/browse/UHF-8706)

- Send indexing request to google when a job listing is published.
- A temporary redirect is created for the job listing before sending the request
- Sending deindexing request to google when a job listing is unpublished
- The temporary redirect is removed after the request.

## What was done
- Google api integration using google's integration library
- Read the documentation

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-8706`
  * `make fresh`
* Run `make drush-cr`
* You must set the api key. It can just be for example empty json object as string `'{}'`
  * local.settings.php: `$config['helfi_google_api.settings']['indexing_api_key'] = 'key-goes-here'`
  * Even with correct api-key, local environment will get an error from API
  * The api key is set to production environment key vault.


## How to test
You might want to use xdebug:
- Set breakpoint in GoogleApi.php
  - Lines 103 and 138, the line where the request is executed.

You can try either by drush-command OR by running drush cron after changing the scheduled date from one of the job listings.

When sending an indexing request:
- See the url which is about to be sent to google api
  - it should be the url to the job listing + `-{timestamp}`
  - If you execute the query, you should see an api error saying that cannot resolve the owner of the url.
  - If you go to edit the job listing in admin-ui, you should see that a redirect has been created for the job listing

When sending an deindexing request
- Follow the indexing-instructions (run drush command or fiddle with the scheduler etc.)
- See that the url matches the redirect
- See that the redirect is deleted after the operation is done.


A command to check url indexing status:
You can try sending a status request by running drush-command. One real url has been indexed and deindexed using the api. you can check the status by running the following drush command:
`drush helfi:google-entity-index-status https://hel.fi/fi/avoimet-tyopaikat/avoimet-tyopaikat/sotepe-02-353-24`

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation


[UHF-8706]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-8706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ