### PR TITLE
UHF-X: trim links

### DIFF
--- a/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
+++ b/public/modules/custom/helfi_rekry_content/helfi_rekry_content.install
@@ -7,6 +7,7 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\media\Entity\Media;
 use Drupal\migrate\MigrateExecutable;
 use Drupal\migrate\MigrateMessage;
@@ -363,5 +364,70 @@ function helfi_rekry_content_update_9009(): void {
     $database
       ->schema()
       ->dropTable($table_name);
+  }
+}
+
+/**
+ * Trim links.
+ */
+function helfi_rekry_content_update_9010(): void {
+  $fields = [
+    'node' => [
+      'field_link_to_presentation',
+    ],
+  ];
+
+  $config = \Drupal::configFactory();
+  $entityUsageConfig = $config
+    ->getEditable('entity_usage.settings');
+
+  $trackEnabledSourceEntityTypes = $entityUsageConfig
+    ->get('track_enabled_source_entity_types');
+
+  // Disable entity_usage module.
+  $entityUsageConfig->set('track_enabled_source_entity_types', []);
+  $entityUsageConfig->save();
+
+  $entityTypeManager = \Drupal::entityTypeManager();
+
+  foreach ($fields as $entityType => $fields) {
+    foreach ($fields as $fieldName) {
+      $query = $entityTypeManager
+        ->getStorage($entityType)
+        ->getQuery();
+
+      $conditionGroup = $query->orConditionGroup();
+      $conditionGroup
+        ->condition($fieldName, '% ', 'LIKE')
+        ->condition($fieldName, ' %', 'LIKE');
+
+      $ids = $query
+        ->exists($fieldName)
+        ->condition($conditionGroup)
+        ->accessCheck(FALSE)
+        ->execute();
+
+      foreach ($ids as $id) {
+        $entity = $entityTypeManager->getStorage($entityType)
+          ->load($id);
+
+        assert($entity instanceof TranslatableInterface);
+        foreach ($entity->getTranslationLanguages() as $language) {
+          $entity = $entity->getTranslation($language->getId());
+
+          // Trim urls.
+          $links = array_map(static fn ($link) => array_merge($link, [
+            'uri' => trim($link['uri']),
+          ]), $entity->get($fieldName)->getValue());
+
+          $entity->set($fieldName, $links);
+          $entity->save();
+        }
+      }
+    }
+
+    // Re-enable entity_usage module.
+    $entityUsageConfig->set('track_enabled_source_entity_types', $trackEnabledSourceEntityTypes);
+    $entityUsageConfig->save();
   }
 }

--- a/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listings.yml
@@ -185,6 +185,8 @@ process:
       plugin: callback
       callable: _helfi_rekry_content_add_schema
       source: link_to_presentation
+    - plugin: callback
+      callable: trim
   field_organization/target_id:
     plugin: entity_lookup
     entity_type: taxonomy_term


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Sentry: https://sentry.test.hel.ninja/organizations/city-of-helsinki/issues/16339/

`symfony/http-foundation` 6.4.14 throws an error if link ends with ASCII control characters or spaces. In rekry, nodes `["16452", "17133", "17149", "17150", "17238", "17314"]` have links that end with spaces. 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UFH-X-trim-links`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Check that `drush cron` works
* [x] Check `drush migrate:import helfi_rekry_jobs:all --update --reset-threshold 1`, links with spaces don't come back.
* [ ] Check:
  * https://helfi-rekry.docker.so/en/open-jobs/node/16452
  * https://helfi-rekry.docker.so/en/open-jobs/node/16452
  * https://helfi-rekry.docker.so/en/open-jobs/node/17133
  * https://helfi-rekry.docker.so/en/open-jobs/node/17149
  * https://helfi-rekry.docker.so/en/open-jobs/node/17150 
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR
