### PR TITLE
UHF-10941: Hakuvahti Sentry error

### DIFF
--- a/conf/cmi/search_api.index.job_listings.yml
+++ b/conf/cmi/search_api.index.job_listings.yml
@@ -26,19 +26,16 @@ dependencies:
     - scheduler
     - search_api
     - helfi_react_search
+    - helfi_rekry_content
 id: job_listings
 name: 'Job listings'
 description: ''
 read_only: false
 field_settings:
   _language:
-    label: 'Legacy Language'
-    datasource_id: 'entity:node'
-    property_path: langcode
+    label: Language
+    property_path: _language
     type: string
-    dependencies:
-      module:
-        - node
   employment_id:
     label: 'Employment » Luokittelutermi » Termin ID'
     datasource_id: 'entity:node'
@@ -343,6 +340,7 @@ processor_settings:
       - field_recruitment_id
       - field_search_id
       - langcode
+  language_field: {  }
   language_with_fallback: {  }
   project_execution_schedule: {  }
   project_image_absolute_url: {  }

--- a/public/modules/custom/helfi_hakuvahti/helfi_hakuvahti.module
+++ b/public/modules/custom/helfi_hakuvahti/helfi_hakuvahti.module
@@ -12,7 +12,7 @@ declare(strict_types=1);
 /**
  * Implements hook_theme().
  */
-function helfi_hakuvahti_theme() {
+function helfi_hakuvahti_theme(): array {
   return [
     'hakuvahti_form' => [
       'variables' => [

--- a/public/modules/custom/helfi_hakuvahti/templates/hakuvahti-confirmation.html.twig
+++ b/public/modules/custom/helfi_hakuvahti/templates/hakuvahti-confirmation.html.twig
@@ -1,0 +1,2 @@
+{{ title }}
+{{ message }}

--- a/public/modules/custom/helfi_hakuvahti/templates/hakuvahti-form.html.twig
+++ b/public/modules/custom/helfi_hakuvahti/templates/hakuvahti-form.html.twig
@@ -1,0 +1,2 @@
+{{ title }}
+{{ message }}

--- a/public/modules/custom/helfi_hakuvahti/tests/src/Kernel/HakuvahtiControllerTest.php
+++ b/public/modules/custom/helfi_hakuvahti/tests/src/Kernel/HakuvahtiControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\helfi_hakuvahti\Kernel;
+
+use Drupal\Core\Url;
+use Drupal\KernelTests\KernelTestBase;
+use Drupal\Tests\helfi_api_base\Traits\ApiTestTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\Loader\Configurator\Traits\PropertyTrait;
+use Symfony\Component\HttpFoundation\Response as SymfonyResponse;
+
+/**
+ * Tests for hakuvahti controller.
+ */
+class HakuvahtiControllerTest extends KernelTestBase {
+
+  use ApiTestTrait;
+  use UserCreationTrait;
+  use PropertyTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'user',
+    'system',
+    'helfi_hakuvahti',
+  ];
+
+  /**
+   * {@inheritDoc}
+   */
+  public function setUp(): void {
+    parent::setUp();
+
+    $this->setUpCurrentUser(permissions: ['access content']);
+  }
+
+  /**
+   * Tests handleConfirmFormSubmission.
+   */
+  public function testHandleConfirmFormSubmission(): void {
+    $this->container->set(ClientInterface::class, $this->createMockHttpClient([
+      new Response(200, body: 'success'),
+      new Response(404, body: 'not found'),
+      new Response(500, body: 'fail'),
+      new RequestException("womp womp", new Request('POST', 'test')),
+    ]));
+
+    $logger = $this->prophesize(LoggerInterface::class);
+    $this->container->set('logger.channel.helfi_hakuvahti', $logger->reveal());
+
+    // Get request.
+    $response = $this->makeRequest('GET', 'helfi_hakuvahti.confirm', ['hash' => 'a', 'subscription' => 'b']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('Confirm saved search', $response->getContent() ?? '');
+
+    // Success.
+    $response = $this->makeRequest('POST', 'helfi_hakuvahti.confirm', ['hash' => 'a', 'subscription' => 'b']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('Search saved successfully', $response->getContent() ?? '');
+
+    // Not found.
+    $response = $this->makeRequest('POST', 'helfi_hakuvahti.confirm', ['hash' => 'a', 'subscription' => 'b']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('Confirmation failed', $response->getContent() ?? '');
+
+    // Server error.
+    $response = $this->makeRequest('POST', 'helfi_hakuvahti.confirm', ['hash' => 'a', 'subscription' => 'b']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('Confirmation failed', $response->getContent() ?? '');
+
+    // Guzzle exception.
+    $response = $this->makeRequest('POST', 'helfi_hakuvahti.confirm', ['hash' => 'a', 'subscription' => 'b']);
+    $this->assertEquals(200, $response->getStatusCode());
+    $this->assertStringContainsString('Confirmation failed', $response->getContent() ?? '');
+  }
+
+  /**
+   * Process a request.
+   *
+   * @param string $method
+   *   HTTP method.
+   * @param string $route
+   *   Drupal route.
+   * @param array $query
+   *   Query parameters.
+   *
+   * @return \Symfony\Component\HttpFoundation\Response
+   *   Controller response.
+   */
+  private function makeRequest(string $method, string $route, array $query = []): SymfonyResponse {
+    $url = Url::fromRoute($route, options: [
+      'query' => $query,
+    ]);
+
+    $request = $this->getMockedRequest($url->toString(), $method);
+
+    return $this->processRequest($request);
+  }
+
+}

--- a/public/modules/custom/helfi_rekry_content/src/Plugin/search_api/processor/LanguageFieldProcessor.php
+++ b/public/modules/custom/helfi_rekry_content/src/Plugin/search_api/processor/LanguageFieldProcessor.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\helfi_rekry_content\Plugin\search_api\processor;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\search_api\Datasource\DatasourceInterface;
+use Drupal\search_api\Item\ItemInterface;
+use Drupal\search_api\Processor\ProcessorPluginBase;
+use Drupal\search_api\Processor\ProcessorProperty;
+
+/**
+ * Adds `_language` to the index.
+ *
+ * This processor adds _language field to the search api index. The field was
+ * renamed to `search_api_language` in elasticsearch_connector v8 update. We
+ * cannot modify rekry search api index without breaking existing hakuvahti
+ * queries.
+ *
+ * @SearchApiProcessor(
+ *   id = "language_field",
+ *   label = @Translation("Language field"),
+ *   description = @Translation("Add _language field to the index."),
+ *   stages = {
+ *     "add_properties" = 20,
+ *   },
+ *   locked = true,
+ *   hidden = true,
+ * )
+ */
+class LanguageFieldProcessor extends ProcessorPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getPropertyDefinitions(DatasourceInterface $datasource = NULL): array {
+    $properties = [];
+
+    if (!$datasource) {
+      $definition = [
+        'label' => $this->t('Language'),
+        'description' => $this->t('The legacy _language field.'),
+        'type' => 'string',
+        'processor_id' => $this->getPluginId(),
+      ];
+      $properties['_language'] = new ProcessorProperty($definition);
+    }
+
+    return $properties;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function addFieldValues(ItemInterface $item): void {
+    $object = $item->getOriginalObject()->getValue();
+
+    if ($object instanceof EntityInterface) {
+      $indexableValue = $object->language()->getId();
+
+      $itemFields = $item->getFields();
+      $itemFields = $this->getFieldsHelper()
+        ->filterForPropertyPath($itemFields, NULL, '_language');
+
+      foreach ($itemFields as $itemField) {
+        $itemField->addValue($indexableValue);
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
# [UHF-10941](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10941)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Debug Sentry issue: https://sentry.hel.fi/organizations/city-of-helsinki/issues/35962/?project=93&referrer=slack
  * Hakuvahti responds with 404 if:
    * Submission has been deleted after (`UNCONFIRMED_SUBSCRIPTION_MAX_AGE`).
    * Submission has already been confirmed.
  * I did not find a anything odd in the behaviour.
  * Changed the logging so that if hakuvahti responds with 404, no errors are logged to Sentry.   
* Fixed unrelated elasticsearch issue: Task area & Type of employment inputs in search form do not work because of elasticseach_connector v8 ugprade.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10941`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] `drush sapi-rt; drush sapi-c; drush sapi-i`, https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/etsi-avoimia-tyopaikkoja search works.
* [x] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10941]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ