### PR TITLE
Allow videos in non-finnish job listings

### DIFF
--- a/public/modules/custom/helfi_rekry_content/migrations/job_listing_videos.yml
+++ b/public/modules/custom/helfi_rekry_content/migrations/job_listing_videos.yml
@@ -18,8 +18,6 @@ source:
       type: string
   plugin: helbit_open_jobs
   track_changes: true
-  langcodes:
-    - fi
   fields:
     -
       name: id


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

From #kuuma_linja:
For some reason, video migration only looked at Finnish job listings. With this change, `kasko-04-340-24` should get video.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-video-migration`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] `drush mim helfi_rekry_videos; drush mim helfi_rekry_jobs --reset-threshold 1 --update`
* [ ] Check that https://helfi-rekry.docker.so/sv/lediga-jobb/lediga-jobb/kasko-04-340-24 has video.
* [ ] Check that code follows our standards