### PR TITLE
UHF-9568: Changed search views to use reusable template

### DIFF
--- a/public/themes/custom/hdbt_subtheme/templates/views/views-view--job-listing-search.html.twig
+++ b/public/themes/custom/hdbt_subtheme/templates/views/views-view--job-listing-search.html.twig
@@ -2,81 +2,15 @@
 /**
  * @file
  * Theme override for main view template.
- *
- * Available variables:
- * - attributes: Remaining HTML attributes for the element.
- * - css_name: A css-safe version of the view name.
- * - css_class: The user-specified classes names, if any.
- * - header: The optional header.
- * - footer: The optional footer.
- * - rows: The results of the view query, if any.
- * - empty: The content to display if there are no rows.
- * - pager: The optional pager next/prev links to display.
- * - exposed: Exposed widget form/info to display.
- * - feed_icons: Optional feed icons to display.
- * - more: An optional link to the next page of results.
- * - title: Title of the view, only used when displaying in the admin preview.
- * - title_prefix: Additional output populated by modules, intended to be
- *   displayed in front of the view title.
- * - title_suffix: Additional output populated by modules, intended to be
- *   displayed after the view title.
- * - attachment_before: An optional attachment view to be displayed before the
- *   view content.
- * - attachment_after: An optional attachment view to be displayed after the
- *   view content.
- * - dom_id: Unique id for every view being printed to give unique class for
- *   Javascript.
- *
- * @see template_preprocess_views_view()
  */
 #}
-{% set classes = [
-  'views',
-  'views--' ~ id|clean_class,
-  'views--' ~ display_id|clean_class,
-  dom_id ? 'js-view-dom-id-' ~ dom_id,
-  'unit-search__content'
-] %}
 
-<div{{attributes.addClass(classes)}}>
-  {{ title_prefix }}
-  {{ title }}
-  {{ title_suffix }}
-
-  {% if header %}
-    <header>
-      {{ header }}
-    </header>
-  {% endif %}
-
-  {{ exposed }}
-  {{ attachment_before }}
-
-  <div class="unit-search__results" data-id-number="{{ dom_id }}">
-    <h3 class="unit-search__count-container">
-      {%- if total_rows -%}
-        {{ total_rows }} {% trans with {'context': 'Job listing search count'}%}open job listing{% plural total_rows ?? 0 %}open job listings{% endtrans %}
-      {%- else -%}
-        {{ 'No results'|t({}, {'context' : 'Unit search no results title'}) }}
-      {%- endif -%}
-    </h3>
-
-    {%- if empty -%}
-      <p>{{ 'No results were found for the criteria you entered. Try changing your search criteria.'|t({}, {'context' : 'Unit search no results text'}) }}</p>
+{% embed '@hdbt/component/unit-search.twig'%}
+  {% block count_container%}
+    {%- if total_rows -%}
+      {{ total_rows }} {% trans with {'context': 'Job listing search count'}%}open job listing{% plural total_rows ?? 0 %}open job listings{% endtrans %}
+    {%- else -%}
+      {{ 'No results'|t({}, {'context' : 'Unit search no results title'}) }}
     {%- endif -%}
-
-    {{ rows }}
-    {{ pager }}
-  </div>
-
-  {{ attachment_after }}
-  {{ more }}
-
-  {% if footer %}
-    <footer>
-      {{ footer }}
-    </footer>
-  {% endif %}
-
-  {{ feed_icons }}
-</div>
+  {% endblock count_container %}
+{% endembed %}


### PR DESCRIPTION
# [UHF-9568](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9568)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Changed view templates to use new reusable template

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9568`
  * `make fresh`
* Update the HDBT theme
  * `composer require drupal/hdbt:dev-UHF-9568`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] See instructions in hdbt
* [ ] Check that code follows our standards

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [ ] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [ ] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* https://github.com/City-of-Helsinki/drupal-hdbt/pull/1211
* https://github.com/City-of-Helsinki/drupal-helfi-kasvatus-koulutus/pull/804
* https://github.com/City-of-Helsinki/drupal-helfi-sote/pull/999
* https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/687
* https://github.com/City-of-Helsinki/drupal-helfi-kymp/pull/1051


[UHF-9568]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ