### PR TITLE
UHF-X: Fix JobListingHideMissingSubscriber

### DIFF
--- a/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingHideMissingSubscriber.php
+++ b/public/modules/custom/helfi_rekry_content/src/EventSubscriber/JobListingHideMissingSubscriber.php
@@ -117,9 +117,7 @@ class JobListingHideMissingSubscriber implements EventSubscriberInterface {
    */
   protected function getJobListingMigrations(): array {
     return [
-      'helfi_rekry_jobs:all',
-      'helfi_rekry_jobs:all_en',
-      'helfi_rekry_jobs:all_sv',
+      'helfi_rekry_jobs',
     ];
   }
 


### PR DESCRIPTION
# [UHF-11166](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11166)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Job listing migrations was renamed at some point, which broke JobListingHideMissingSubscriber.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-fix-JobListingHideMissingSubscriber`
  * `rm dump.sql` (use fresh db from test)
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/kasko-01-209-25 is published
* [ ] Run job migration: `drush queue:run job_listing_unpublish_worker`
* [ ] Check that https://helfi-rekry.docker.so/fi/avoimet-tyopaikat/avoimet-tyopaikat/kasko-01-209-25 is no longer published

[UHF-11166]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ