### PR TITLE
UHF-11687 job google indexing fills the queue

### DIFF
--- a/public/modules/custom/helfi_google_api/src/Drush/Commands/GoogleIndexingApiCommands.php
+++ b/public/modules/custom/helfi_google_api/src/Drush/Commands/GoogleIndexingApiCommands.php
@@ -195,7 +195,7 @@ final class GoogleIndexingApiCommands extends DrushCommands {
       return DrushCommands::EXIT_SUCCESS;
     }
 
-    $this->io()->writeln('Url indexed succesfully.');
+    $this->io()->writeln('Url indexed successfully.');
     return DrushCommands::EXIT_SUCCESS;
   }
 

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobMigrationSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobMigrationSubscriber.php
@@ -70,6 +70,7 @@ class JobMigrationSubscriber implements EventSubscriberInterface {
     }
 
     // Prevent duplicate queue entries.
+    // @phpstan-ignore-next-line
     $results = $this->database
       ->select('queue')
       ->extend(PagerSelectExtender::class)

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobMigrationSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobMigrationSubscriber.php
@@ -22,13 +22,13 @@ class JobMigrationSubscriber implements EventSubscriberInterface {
   /**
    * The constructor.
    *
-   * @param EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
-   * @param QueueFactory $queueFactory
+   * @param \Drupal\Core\Queue\QueueFactory $queueFactory
    *   The queue factory.
-   * @param Connection $database
+   * @param \Drupal\Core\Database\Connection $database
    *   The connection.
-   * @param JobIndexingService $jobIndexingService
+   * @param \Drupal\helfi_google_api\JobIndexingService $jobIndexingService
    *   The job indexing service.
    */
   public function __construct(
@@ -78,7 +78,7 @@ class JobMigrationSubscriber implements EventSubscriberInterface {
         'data',
       ])
       ->condition('name', 'job_listing_indexing_request')
-      ->condition('data', '%"'.$id.'"%', 'LIKE')
+      ->condition('data', '%"' . $id . '"%', 'LIKE')
       ->limit(1)
       ->execute()
       ->fetchAll();
@@ -93,7 +93,7 @@ class JobMigrationSubscriber implements EventSubscriberInterface {
       $node,
       $node->language()->getId()
     );
-    if($temp_redirect_exists) {
+    if ($temp_redirect_exists) {
       return;
     }
 

--- a/public/modules/custom/helfi_google_api/src/EventSubscriber/JobMigrationSubscriber.php
+++ b/public/modules/custom/helfi_google_api/src/EventSubscriber/JobMigrationSubscriber.php
@@ -83,7 +83,7 @@ class JobMigrationSubscriber implements EventSubscriberInterface {
       ->execute()
       ->fetchAll();
 
-    if ($results > 0) {
+    if (is_array($results) && count($results) > 0) {
       return;
     }
 

--- a/public/modules/custom/helfi_google_api/src/Plugin/QueueWorker/IndexingWorker.php
+++ b/public/modules/custom/helfi_google_api/src/Plugin/QueueWorker/IndexingWorker.php
@@ -56,7 +56,7 @@ final class IndexingWorker extends QueueWorkerBase implements ContainerFactoryPl
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
-      $container->get('Drupal\helfi_google_api\JobIndexingService'),
+      $container->get(JobIndexingService::class),
     );
   }
 


### PR DESCRIPTION
# [UHF-11687](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11687)

## What was done
- Prevent requeuing already queued nodes
- Prevent reindexing already indexed nodes
  - Google api has 100 item daily limit, no need to waste it on reindexing since the initial indexing request has already been done.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11687`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Empty the queue manually
  - `drush sqlc`, `delete from queue where name = "job_listing_indexing_request";`
- Reset the job indexing migration
  -  `drush migrate:reset-status helfi_rekry_jobs` 
- Run job migration
  - `drush migrate:import helfi_rekry_jobs`
- Go see that there are new items in queue
  - `drush sqlc`, `select count(item_id) from queue where name = "job_listing_indexing_request";`
  - Remember the count.
- Run the migration again
- Go see that the queue has still the same amount of items
  - `drush sqlc`, `select count(item_id) from queue where name = "job_listing_indexing_request";`



[UHF-11687]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ