### PR TITLE
UHF-11591 added possibility to change delimiter from csv

### DIFF
--- a/public/modules/custom/helfi_hakuvahti/src/Form/SelectedFiltersCsvForm.php
+++ b/public/modules/custom/helfi_hakuvahti/src/Form/SelectedFiltersCsvForm.php
@@ -45,6 +45,16 @@ final class SelectedFiltersCsvForm extends FormBase {
     $first_entry = $this->tracker->getFirstEntry();
     $date = $first_entry ? (new \DateTime($first_entry->created_at))->format('Y-m-d') : NULL;
 
+    $form['csv_delimiter'] = [
+      '#type' => 'select',
+      '#options' => [
+        ';' => $this->t('Semicolon'),
+        ',' => $this->t('Comma'),
+      ],
+      '#title' => $this->t('CSV Delimiter'),
+      '#description' => $this->t("Change the delimiter if the csv file won't open properly."),
+    ];
+
     $form['from'] = [
       '#type' => 'date',
       '#date_timezone' => 'Europe/Helsinki',
@@ -89,6 +99,8 @@ final class SelectedFiltersCsvForm extends FormBase {
       return;
     }
 
+    $delimiter = $form_state->getValue('csv_delimiter');
+
     try {
       $rows = $this->tracker->getSavedFilters($from, $to);
       if (!$rows) {
@@ -96,7 +108,7 @@ final class SelectedFiltersCsvForm extends FormBase {
         return;
       }
 
-      $csv_string = $this->tracker->createCsvStringFromArray($rows);
+      $csv_string = $this->tracker->createCsvStringFromArray($rows, $delimiter);
     }
     catch (\Exception $e) {
       $this->handleError($this->t('Something went wrong: @message', ['@message' => $e->getMessage()]), $form_state);

--- a/public/modules/custom/helfi_hakuvahti/src/HakuvahtiTracker.php
+++ b/public/modules/custom/helfi_hakuvahti/src/HakuvahtiTracker.php
@@ -96,11 +96,13 @@ readonly class HakuvahtiTracker {
    *   Datetime filter.
    * @param \DateTime|null $to
    *   Datetime filter.
+   * @param string $delimiter
+   *   CSV delimiter.
    *
    * @return string
    *   The csv as a string.
    */
-  public function createCsvString(?\DateTime $from = NULL, ?\DateTime $to = NULL): string {
+  public function createCsvString(?\DateTime $from = NULL, ?\DateTime $to = NULL, string $delimiter = ';'): string {
     try {
       $rows = $this->getSavedFilters($from, $to);
     }
@@ -113,7 +115,7 @@ readonly class HakuvahtiTracker {
       throw new \Exception("No results found");
     }
 
-    return $this->createCsvStringFromArray($rows);
+    return $this->createCsvStringFromArray($rows, $delimiter);
   }
 
   /**
@@ -125,8 +127,7 @@ readonly class HakuvahtiTracker {
    * @return string
    *   The csv string.
    */
-  public function createCsvStringFromArray(array $rows): string {
-    $delimiter = ',';
+  public function createCsvStringFromArray(array $rows, string $delimiter): string {
     $filePath = 'php://temp';
     $handle = fopen($filePath, 'w+');
 

--- a/public/modules/custom/helfi_hakuvahti/src/HakuvahtiTracker.php
+++ b/public/modules/custom/helfi_hakuvahti/src/HakuvahtiTracker.php
@@ -123,6 +123,8 @@ readonly class HakuvahtiTracker {
    *
    * @param array $rows
    *   Data as array.
+   * @param string $delimiter
+   *   CSV delimiter.
    *
    * @return string
    *   The csv string.

--- a/public/modules/custom/helfi_hakuvahti/src/HakuvahtiTracker.php
+++ b/public/modules/custom/helfi_hakuvahti/src/HakuvahtiTracker.php
@@ -127,7 +127,7 @@ readonly class HakuvahtiTracker {
    * @return string
    *   The csv string.
    */
-  public function createCsvStringFromArray(array $rows, string $delimiter): string {
+  public function createCsvStringFromArray(array $rows, string $delimiter = ';'): string {
     $filePath = 'php://temp';
     $handle = fopen($filePath, 'w+');
 

--- a/public/modules/custom/helfi_hakuvahti/tests/src/Kernel/HakuvahtiTrackerTest.php
+++ b/public/modules/custom/helfi_hakuvahti/tests/src/Kernel/HakuvahtiTrackerTest.php
@@ -54,7 +54,7 @@ class HakuvahtiTrackerTest extends KernelTestBase {
     $saved = $tracker->saveSelectedFilters($filters);
     $this->assertTrue($saved);
 
-    $csv = $tracker->createCsvString($week_ago, $now);
+    $csv = $tracker->createCsvString($week_ago, $now, ';');
     $this->assertNotEmpty($csv);
     $this->assertCsv($csv, 'Qwerty');
   }
@@ -73,6 +73,7 @@ class HakuvahtiTrackerTest extends KernelTestBase {
     $tracker->saveSelectedFilters($filters);
 
     $form_state = new FormState();
+    $form_state->setValue('csv_delimiter', ';');
     $form_state->setValue(
       'from',
       (new \DateTime(date('Y-m-d H:i.s', strtotime('-1 week'))))->format('Y-m-d')
@@ -105,7 +106,7 @@ class HakuvahtiTrackerTest extends KernelTestBase {
    *   The words to look for.
    */
   private function assertCsv(string $csv, string $needle): void {
-    $this->assertContains($needle, explode(',', $csv));
+    $this->assertContains($needle, explode(';', $csv));
   }
 
 }

--- a/public/modules/custom/helfi_hakuvahti/translations/fi.po
+++ b/public/modules/custom/helfi_hakuvahti/translations/fi.po
@@ -110,3 +110,9 @@ msgstr "Jokin meni pieleen: @message"
 
 msgid "Hakuvahti csv download"
 msgstr "Hakuvahti seuranta"
+
+msgid "CSV Delimiter"
+msgstr "CSV erotinmerkki"
+
+msgid "Change the delimiter if the csv file won't open properly."
+msgstr "Vaihda erotinmerkkiä jos csv-tiedosto ei avaudu formatoituna käyttämässäsi ohjelmistossa."


### PR DESCRIPTION
# [UHF-11591](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11591)
Added  delimiter option to the form

## What was done
<!-- Describe what was done -->

* This thing was fixed

## How to install
## How to test
[Check the original PR](https://github.com/City-of-Helsinki/drupal-helfi-rekry/pull/758)

Test that the delimiter option changes the csv-files delimiter


[UHF-11591]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ