### PR TITLE
UHF-12167: email backend validation

### DIFF
--- a/public/modules/custom/helfi_hakuvahti/src/Controller/HelfiHakuvahtiSubscribeController.php
+++ b/public/modules/custom/helfi_hakuvahti/src/Controller/HelfiHakuvahtiSubscribeController.php
@@ -67,6 +67,16 @@ final class HelfiHakuvahtiSubscribeController extends ControllerBase {
     $body = $request->getContent();
     $bodyObj = json_decode($body);
 
+    if (!$bodyObj->{'email'} || !filter_var($bodyObj->{'email'}, FILTER_VALIDATE_EMAIL)) {
+      return new JsonResponse(
+        [
+          'success' => FALSE,
+          'error' => 'Error while validating email address.'
+        ],
+        Response::HTTP_BAD_REQUEST
+      );
+    }
+
     // Collect the filter values for saving.
     $task_areas = [];
     $employment_type_labels = [];


### PR DESCRIPTION
# [UHF-12167](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12167)

## What was done
Prevent bad email from reaching ATV




## How to install

Start by testing only the backend validation. Then add the HDBT-react-fix.

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12167`
  * `make fresh`
* Run `make drush-cr`
* At this point test the backend fix
* composer require drupal/hdbt:dev-UHF-12167
* run `drush cr` and refresh the job search page without caches

## How to test

BACKEND-FIX:
- Go to the job search page
- Open inspector so you can check the response after submitting bad email address
- Fill the hakuvahti, add bad email address, for example `test@testfi` and submit
- Check the response. You should see 400 and an message which says that bad email

FRONTEND-FIX:
- After setupping, follow the [hdbt-pr test instructions ](https://github.com/City-of-Helsinki/drupal-hdbt/pull/1361)
- You should be unable to submit
- You should see an appropriate error message 




## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
[HDBT](https://github.com/City-of-Helsinki/drupal-hdbt/pull/1361)
